### PR TITLE
Resolve subsetting wrappers per view: statics keep the DS fold, weighted counts them local

### DIFF
--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
@@ -12,8 +12,7 @@
 			"module": "react-router-dom",
 			"name": "BrowserRouter",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]",
@@ -26,8 +25,7 @@
 			"weight": 1,
 			"props": [
 				"store"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]",
@@ -40,8 +38,7 @@
 			"weight": 1,
 			"props": [
 				"theme"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/GlobalStyle[0]",
@@ -52,8 +49,7 @@
 			"module": "styled-components",
 			"name": "createGlobalStyle",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/AppRoutes[1]",
@@ -64,8 +60,7 @@
 			"module": "src/Routes.tsx",
 			"name": "AppRoutes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]",
@@ -76,8 +71,7 @@
 			"module": "react-router-dom",
 			"name": "Routes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[0]",
@@ -91,8 +85,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryListPage[0]",
@@ -103,8 +96,7 @@
 			"module": "src/pages/CategoryListPage/CategoryListPage.tsx",
 			"name": "CategoryListPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[1]",
@@ -118,8 +110,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryDetailPage[0]",
@@ -130,8 +121,7 @@
 			"module": "src/pages/CategoryDetailPage/CategoryDetailPage.tsx",
 			"name": "CategoryDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[2]",
@@ -145,8 +135,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/RestaurantDetailPage[0]",
@@ -157,8 +146,7 @@
 			"module": "src/pages/RestaurantDetailPage/RestaurantDetailPage.tsx",
 			"name": "RestaurantDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[3]",
@@ -172,8 +160,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CheckoutPage[0]",
@@ -184,8 +171,7 @@
 			"module": "src/pages/CheckoutPage/CheckoutPage.tsx",
 			"name": "CheckoutPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[4]",
@@ -199,8 +185,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/SuccessPage[0]",
@@ -211,8 +196,7 @@
 			"module": "src/pages/SuccessPage/SuccessPage.tsx",
 			"name": "SuccessPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[5]",
@@ -226,8 +210,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/HomePage[0]",
@@ -238,8 +221,7 @@
 			"module": "src/pages/HomePage/HomePage.tsx",
 			"name": "HomePage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AnimatedIllustration/span[0]/Lottie[0]",
@@ -255,8 +237,7 @@
 				"play",
 				"loop",
 				"animationData"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Badge/Container[0]/Body[0]",
@@ -270,8 +251,7 @@
 			"props": [
 				"type",
 				"size"
-			],
-			"instances": 3.5
+			]
 		},
 		{
 			"path": "Breadcrumb/LinkText[0]/Link[0]",
@@ -284,8 +264,7 @@
 			"weight": 0.5,
 			"props": [
 				"to"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "Button/StyledButton[0]",
@@ -304,8 +283,7 @@
 				"$withIcon",
 				"className",
 				"..."
-			],
-			"instances": 177
+			]
 		},
 		{
 			"path": "Button/Icon[0]",
@@ -320,8 +298,7 @@
 				"color",
 				"size",
 				"name"
-			],
-			"instances": 177
+			]
 		},
 		{
 			"path": "Carousel/PreviousButton[0]",
@@ -336,8 +313,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Carousel/NextButton[0]",
@@ -352,8 +328,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Rounded/Title[0]/Body[0]",
@@ -366,8 +341,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Squared/FloatingTitle[0]/Body[0]",
@@ -381,8 +355,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Rounded[0]",
@@ -396,8 +369,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Squared[0]",
@@ -411,8 +383,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ErrorBlock/ErrorContainer[0]/Heading[0]",
@@ -425,8 +396,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ErrorBlock/ErrorContainer[0]/Body[2]",
@@ -437,8 +407,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "ErrorBlock/ErrorContainer[0]/Button[3]",
@@ -451,8 +420,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/Logo[0]",
@@ -466,8 +434,7 @@
 			"props": [
 				"large",
 				"logoOnly"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[1]",
@@ -481,8 +448,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[2]",
@@ -496,8 +462,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[3]",
@@ -510,8 +475,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "FooterCard/FooterCardContainer[0]/Heading[0]",
@@ -524,8 +488,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 54
+			]
 		},
 		{
 			"path": "FooterCard/li[0]/Body[0]",
@@ -536,8 +499,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 54
+			"props": []
 		},
 		{
 			"path": "FooterCard/Link[0]",
@@ -550,8 +512,7 @@
 			"weight": 0.5,
 			"props": [
 				"to"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Tooltip.Root[0]",
@@ -562,8 +523,7 @@
 			"module": "@base-ui/react/tooltip",
 			"name": "Tooltip.Root",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ThemeToggle/Tooltip.Root[0]/Tooltip.Trigger[0]",
@@ -576,8 +536,7 @@
 			"weight": 1,
 			"props": [
 				"render"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -594,8 +553,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Tooltip.Root[0]/Tooltip.Portal[1]",
@@ -606,8 +564,7 @@
 			"module": "@base-ui/react/tooltip",
 			"name": "Tooltip.Portal",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ThemeToggle/Tooltip.Root[0]/Tooltip.Portal[1]/Tooltip.Positioner[0]",
@@ -620,8 +577,7 @@
 			"weight": 1,
 			"props": [
 				"sideOffset"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Tooltip.Root[0]/Tooltip.Portal[1]/Tooltip.Positioner[0]/TooltipPopup[0]",
@@ -632,8 +588,7 @@
 			"module": "@base-ui/react/tooltip",
 			"name": "Tooltip.Popup",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -647,8 +602,7 @@
 			"props": [
 				"to",
 				"aria-label"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]/Logo[0]",
@@ -659,8 +613,7 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/ThemeToggle[0]",
@@ -671,8 +624,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "ThemeToggle",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]",
@@ -686,8 +638,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]/Button[0]",
@@ -700,8 +651,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]",
@@ -715,8 +665,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]/Button[0]",
@@ -729,8 +678,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/Button[1]",
@@ -745,8 +693,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartText[0]",
@@ -759,8 +706,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartTotal[0]",
@@ -773,8 +719,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/ShoppingCartMenu[0]",
@@ -792,8 +737,7 @@
 				"cartItems",
 				"totalPrice",
 				"onItemChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Header/HeaderComponent[0]",
@@ -812,8 +756,7 @@
 				"toggleCartVisibility",
 				"totalPrice",
 				"saveItem"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "IconButton/StyledButton[0]",
@@ -828,8 +771,7 @@
 				"type",
 				"$small",
 				"..."
-			],
-			"instances": 6
+			]
 		},
 		{
 			"path": "IconButton/StyledButton[0]/Icon[0]",
@@ -844,8 +786,7 @@
 				"name",
 				"size",
 				"color"
-			],
-			"instances": 6
+			]
 		},
 		{
 			"path": "Logo/StyledHeading[0]",
@@ -858,8 +799,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 45
+			]
 		},
 		{
 			"path": "Modal/Dialog.Root[0]",
@@ -873,8 +813,7 @@
 			"props": [
 				"open",
 				"onOpenChange"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Modal/Dialog.Root[0]/Dialog.Portal[0]",
@@ -887,8 +826,7 @@
 			"weight": 1,
 			"props": [
 				"container"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Modal/Dialog.Root[0]/Dialog.Portal[0]/StyledBackdrop[0]",
@@ -901,8 +839,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Modal/Dialog.Root[0]/Dialog.Portal[0]/StyledPopup[1]",
@@ -918,8 +855,7 @@
 				"initialFocus",
 				"data-testid",
 				"aria-label"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Modal/Dialog.Root[0]/Dialog.Portal[0]/StyledPopup[1]/TopBar[0]/Button[0]",
@@ -938,8 +874,7 @@
 				"icon",
 				"aria-label",
 				"iconSize"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageSection/Container[0]/TopContainer[0]/Heading[0]",
@@ -952,8 +887,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "PageSection/Button[0]",
@@ -967,8 +901,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]",
@@ -982,8 +915,7 @@
 			"props": [
 				"color",
 				"highlightColor"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/Skeleton[0]",
@@ -998,8 +930,7 @@
 				"height",
 				"width",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/StyledHeading[0]",
@@ -1012,8 +943,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/StyledHeading[0]/Skeleton[0]",
@@ -1026,8 +956,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Body[1]",
@@ -1040,8 +969,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Body[1]/Skeleton[0]",
@@ -1054,8 +982,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Description[2]",
@@ -1066,8 +993,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Description[2]/Skeleton[0]",
@@ -1078,8 +1004,7 @@
 			"module": "react-loading-skeleton",
 			"name": "default",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Body[3]",
@@ -1092,8 +1017,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/SkeletonTheme[0]/Container[0]/StyledContent[1]/Body[3]/Skeleton[0]",
@@ -1108,8 +1032,7 @@
 				"width",
 				"height",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCard/RestaurantCardSkeleton[0]",
@@ -1120,8 +1043,7 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 1.5
+			"props": []
 		},
 		{
 			"path": "RestaurantCard/Closed[0]/Body[0]",
@@ -1134,8 +1056,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Container[0]/StyledContent[1]/StyledHeading[0]",
@@ -1148,8 +1069,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Container[0]/StyledContent[1]/Review[1]",
@@ -1162,8 +1082,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Container[0]/StyledContent[1]/Description[2]",
@@ -1176,8 +1095,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/StyledBadge[0]",
@@ -1191,8 +1109,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Body[0]",
@@ -1205,8 +1122,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Heading[0]",
@@ -1219,8 +1135,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Review[1]",
@@ -1233,8 +1148,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Body[2]",
@@ -1247,8 +1161,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/Badge[0]",
@@ -1262,8 +1175,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Review/Wrapper[0]/StyledBody[0]",
@@ -1278,8 +1190,7 @@
 				"size",
 				"type",
 				"className"
-			],
-			"instances": 3.5
+			]
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/StyledHeading[0]",
@@ -1293,8 +1204,7 @@
 			"props": [
 				"level",
 				"$withMargin"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "OrderSummary/ShoppingCartItem[0]",
@@ -1308,8 +1218,7 @@
 			"props": [
 				"key",
 				"item"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/Body[0]",
@@ -1320,8 +1229,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 0.5,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/Body[0]",
@@ -1332,8 +1240,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/TotalHeading[1]",
@@ -1346,8 +1253,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Quantity[0]",
@@ -1360,8 +1266,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Name[1]",
@@ -1374,8 +1279,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Price[2]",
@@ -1388,8 +1292,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[0]",
@@ -1402,8 +1305,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[1]",
@@ -1416,8 +1318,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Button[1]",
@@ -1432,8 +1333,7 @@
 				"disabled",
 				"large",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[0]",
@@ -1447,8 +1347,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[1]",
@@ -1459,8 +1358,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[2]",
@@ -1471,8 +1369,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/Select[1]",
@@ -1488,8 +1385,7 @@
 				"onChange",
 				"aria-label",
 				"options"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Sidebar[0]",
@@ -1505,8 +1401,7 @@
 				"onClose",
 				"isOpen",
 				"footer"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Footer[0]",
@@ -1520,8 +1415,7 @@
 			"props": [
 				"onClick",
 				"totalPrice"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/ShoppingCartMenuItem[0]",
@@ -1536,8 +1430,7 @@
 				"key",
 				"item",
 				"onChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]",
@@ -1552,8 +1445,7 @@
 				"open",
 				"swipeDirection",
 				"onOpenChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]",
@@ -1566,8 +1458,7 @@
 			"weight": 1,
 			"props": [
 				"container"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]/SidebarBackdrop[0]",
@@ -1580,8 +1471,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]/SidebarViewport[1]",
@@ -1592,8 +1482,7 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Viewport",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]/SidebarViewport[1]/SidebarPopup[0]",
@@ -1606,8 +1495,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]/SidebarViewport[1]/SidebarPopup[0]/TopBar[0]/Drawer.Title[0]",
@@ -1621,8 +1509,7 @@
 			"props": [
 				"className",
 				"render"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Heading[0]",
@@ -1635,8 +1522,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Sidebar/Drawer.Root[0]/Drawer.Portal[0]/SidebarViewport[1]/SidebarPopup[0]/TopBar[0]/Button[1]",
@@ -1655,8 +1541,7 @@
 				"round",
 				"icon",
 				"iconSize"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "TopBanner/StyledHeading[0]",
@@ -1669,8 +1554,7 @@
 			"weight": 1,
 			"props": [
 				"$inverted"
-			],
-			"instances": 4
+			]
 		},
 		{
 			"path": "Input/Container[0]/MdInput[0]",
@@ -1687,8 +1571,7 @@
 				"className",
 				"...",
 				"autoComplete"
-			],
-			"instances": 7
+			]
 		},
 		{
 			"path": "Select/Body[0]",
@@ -1702,8 +1585,7 @@
 			"props": [
 				"type",
 				"htmlFor"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "<module>/StrictMode[0]",
@@ -1714,8 +1596,7 @@
 			"module": "react",
 			"name": "StrictMode",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "<module>/StrictMode[0]/App[0]",
@@ -1726,8 +1607,7 @@
 			"module": "src/App.tsx",
 			"name": "App",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]",
@@ -1738,8 +1618,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/TopBanner[0]",
@@ -1754,8 +1633,7 @@
 				"title",
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/div[1]/Breadcrumb[0]",
@@ -1768,8 +1646,7 @@
 			"weight": 1,
 			"props": [
 				"items"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/ErrorBlock[0]",
@@ -1786,8 +1663,7 @@
 				"image",
 				"buttonText",
 				"onButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCardSkeleton[0]",
@@ -1800,8 +1676,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCard[0]",
@@ -1816,8 +1691,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]",
@@ -1828,8 +1702,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/TopBanner[0]",
@@ -1843,8 +1716,7 @@
 			"props": [
 				"title",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledHeading[0]",
@@ -1857,8 +1729,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledBody[1]",
@@ -1869,8 +1740,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/CategoryList[2]",
@@ -1883,8 +1753,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]",
@@ -1898,8 +1767,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]/Category[0]",
@@ -1913,8 +1781,7 @@
 			"props": [
 				"...",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]",
@@ -1927,8 +1794,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/TopContainer[0]/StyledHeading[0]",
@@ -1942,8 +1808,7 @@
 			"props": [
 				"level",
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/MultiStepForm[0]",
@@ -1954,8 +1819,7 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/MultiStepForm.tsx",
 			"name": "MultiStepForm",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/OrderDetailsContainer[1]/OrderSummary[0]",
@@ -1968,8 +1832,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[0]",
@@ -1987,8 +1850,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[1]",
@@ -2006,8 +1868,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[2]",
@@ -2026,8 +1887,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[3]",
@@ -2046,8 +1906,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/DisclaimerText[4]",
@@ -2061,8 +1920,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/div[5]/Button[0]",
@@ -2075,8 +1933,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[0]",
@@ -2094,8 +1951,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[1]",
@@ -2113,8 +1969,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[2]",
@@ -2132,8 +1987,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[0]",
@@ -2147,8 +2001,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[1]",
@@ -2161,8 +2014,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/ContactDetails[0]",
@@ -2177,8 +2029,7 @@
 				"formData",
 				"setFormData",
 				"onNext"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/DeliveryDetails[0]",
@@ -2193,8 +2044,7 @@
 				"formData",
 				"setFormData",
 				"onPrevious"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "MultiStepForm/FormContainer[0]/StepIndicator[0]",
@@ -2209,8 +2059,7 @@
 				"title",
 				"currentStep",
 				"amountOfSteps"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/StyledHeading[0]",
@@ -2223,8 +2072,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Body[1]",
@@ -2238,8 +2086,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]",
@@ -2250,8 +2097,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/Banner[0]",
@@ -2262,8 +2108,7 @@
 			"module": "src/pages/HomePage/components/Banner/Banner.tsx",
 			"name": "Banner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/RestaurantsSection[2]",
@@ -2276,8 +2121,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/AwardWinningSection[4]",
@@ -2288,8 +2132,7 @@
 			"module": "src/pages/HomePage/components/AwardWinningSection/AwardWinningSection.tsx",
 			"name": "AwardWinningSection",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/CategoriesSection[6]",
@@ -2302,8 +2145,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[0]",
@@ -2316,8 +2158,7 @@
 			"weight": 1,
 			"props": [
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[1]",
@@ -2328,8 +2169,7 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]",
@@ -2342,8 +2182,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]/StyledButton[0]",
@@ -2354,8 +2193,7 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/StyledHeading[0]",
@@ -2368,8 +2206,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]",
@@ -2382,8 +2219,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]/Button[0]",
@@ -2394,8 +2230,7 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]",
@@ -2410,8 +2245,7 @@
 				"title",
 				"topButtonLabel",
 				"onTopButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]/Carousel[0]",
@@ -2425,8 +2259,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]",
@@ -2440,8 +2273,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]/Category[0]",
@@ -2455,8 +2287,7 @@
 			"props": [
 				"round",
 				"..."
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]",
@@ -2469,8 +2300,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]/Carousel[0]",
@@ -2484,8 +2314,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCardSkeleton[0]",
@@ -2498,8 +2327,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCard[0]",
@@ -2514,8 +2342,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantsSectionComponent[0]",
@@ -2531,8 +2358,7 @@
 				"restaurants",
 				"isLoading",
 				"onRestaurantClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]",
@@ -2545,8 +2371,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]/Carousel[0]",
@@ -2560,8 +2385,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCardSkeleton[0]",
@@ -2574,8 +2398,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCard[0]",
@@ -2590,8 +2413,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]",
@@ -2604,8 +2426,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]",
@@ -2622,8 +2443,7 @@
 				"image",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]",
@@ -2636,8 +2456,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#2",
@@ -2650,8 +2469,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]#2",
@@ -2668,8 +2486,7 @@
 				"image",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]#2",
@@ -2682,8 +2499,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#3",
@@ -2696,8 +2512,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/Spinner[0]",
@@ -2708,8 +2523,7 @@
 			"module": "src/components/Spinner/Spinner.tsx",
 			"name": "Spinner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#4",
@@ -2722,8 +2536,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/FoodItemModal[0]",
@@ -2740,8 +2553,7 @@
 				"onClose",
 				"onItemSave",
 				"onItemRemove"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/TopBanner[1]",
@@ -2755,8 +2567,7 @@
 			"props": [
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Heading[0]",
@@ -2769,8 +2580,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Body[1]",
@@ -2781,8 +2591,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Review[2]",
@@ -2795,8 +2604,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/StyledBadge[0]",
@@ -2810,8 +2618,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]",
@@ -2827,8 +2634,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#2",
@@ -2844,8 +2650,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#3",
@@ -2861,8 +2666,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItem/Quantity[0]",
@@ -2877,8 +2681,7 @@
 				"aria-label",
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Heading[0]",
@@ -2891,8 +2694,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Description[1]",
@@ -2903,8 +2705,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Price[2]",
@@ -2915,8 +2716,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/Modal[0]",
@@ -2930,8 +2730,7 @@
 			"props": [
 				"isOpen",
 				"onClose"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/Heading[0]",
@@ -2942,8 +2741,7 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/StyledBody[1]",
@@ -2954,8 +2752,7 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/Button[0]",
@@ -2973,8 +2770,7 @@
 				"icon",
 				"onClick",
 				"disabled"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/Body[1]",
@@ -2987,8 +2783,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/Button[2]",
@@ -3006,8 +2801,7 @@
 				"icon",
 				"onClick",
 				"disabled"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/StyledButton[1]",
@@ -3021,8 +2815,7 @@
 			"props": [
 				"aria-label",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodSection/div[0]/StyledHeading[0]",
@@ -3035,8 +2828,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodSection/FoodItem[0]",
@@ -3054,8 +2846,7 @@
 				"description",
 				"quantity",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]",
@@ -3068,8 +2859,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/TopBanner[0]",
@@ -3082,8 +2872,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/Body[0]",
@@ -3096,8 +2885,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/StyledHeading[1]",
@@ -3110,8 +2898,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/OrderSummary[2]",
@@ -3124,8 +2911,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]",
@@ -3138,8 +2924,7 @@
 			"weight": 1,
 			"props": [
 				"sticky"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -3150,8 +2935,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/HeaderComponent[0]",
@@ -3164,8 +2948,7 @@
 			"weight": 1,
 			"props": [
 				"logoOnly"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]#2",
@@ -3176,8 +2959,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/Footer[0]#2",
@@ -3188,8 +2970,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
@@ -24,7 +24,9 @@
 			"module": "react-redux",
 			"name": "Provider",
 			"weight": 1,
-			"props": ["store"],
+			"props": [
+				"store"
+			],
 			"instances": 1
 		},
 		{
@@ -36,7 +38,9 @@
 			"module": "styled-components",
 			"name": "ThemeProvider",
 			"weight": 1,
-			"props": ["theme"],
+			"props": [
+				"theme"
+			],
 			"instances": 1
 		},
 		{
@@ -84,7 +88,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -108,7 +115,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -132,7 +142,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -156,7 +169,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -180,7 +196,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -204,7 +223,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -228,7 +250,12 @@
 			"module": "react-lottie-player",
 			"name": "default",
 			"weight": 1,
-			"props": ["style", "play", "loop", "animationData"],
+			"props": [
+				"style",
+				"play",
+				"loop",
+				"animationData"
+			],
 			"instances": 2
 		},
 		{
@@ -240,7 +267,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "size"],
+			"props": [
+				"type",
+				"size"
+			],
 			"instances": 3.5
 		},
 		{
@@ -252,7 +282,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 0.5,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 0.5
 		},
 		{
@@ -264,7 +296,15 @@
 			"module": "@base-ui/react/button",
 			"name": "Button",
 			"weight": 1,
-			"props": ["type", "$large", "$clear", "$round", "$withIcon", "className", "..."],
+			"props": [
+				"type",
+				"$large",
+				"$clear",
+				"$round",
+				"$withIcon",
+				"className",
+				"..."
+			],
 			"instances": 177
 		},
 		{
@@ -276,7 +316,11 @@
 			"module": "src/components/Icon/Icon.tsx",
 			"name": "Icon",
 			"weight": 1,
-			"props": ["color", "size", "name"],
+			"props": [
+				"color",
+				"size",
+				"name"
+			],
 			"instances": 177
 		},
 		{
@@ -288,7 +332,11 @@
 			"module": "src/components/IconButton/IconButton.tsx",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -300,7 +348,11 @@
 			"module": "src/components/IconButton/IconButton.tsx",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -312,7 +364,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -324,7 +378,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -336,7 +393,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Rounded",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -348,7 +408,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Squared",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -360,7 +423,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -384,7 +449,9 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -396,7 +463,10 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": ["large", "logoOnly"],
+			"props": [
+				"large",
+				"logoOnly"
+			],
 			"instances": 18
 		},
 		{
@@ -408,7 +478,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -420,7 +493,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -432,7 +508,9 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 18
 		},
 		{
@@ -444,7 +522,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 54
 		},
 		{
@@ -468,7 +548,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 0.5,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 27
 		},
 		{
@@ -492,7 +574,9 @@
 			"module": "@base-ui/react/tooltip",
 			"name": "Tooltip.Trigger",
 			"weight": 1,
-			"props": ["render"],
+			"props": [
+				"render"
+			],
 			"instances": 27
 		},
 		{
@@ -504,7 +588,13 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["round", "clear", "aria-label", "icon", "onClick"],
+			"props": [
+				"round",
+				"clear",
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -528,7 +618,9 @@
 			"module": "@base-ui/react/tooltip",
 			"name": "Tooltip.Positioner",
 			"weight": 1,
-			"props": ["sideOffset"],
+			"props": [
+				"sideOffset"
+			],
 			"instances": 27
 		},
 		{
@@ -552,7 +644,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "aria-label"],
+			"props": [
+				"to",
+				"aria-label"
+			],
 			"instances": 27
 		},
 		{
@@ -588,7 +683,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -600,7 +698,9 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -612,7 +712,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -624,7 +727,9 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -636,7 +741,11 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "icon", "onClick"],
+			"props": [
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -648,7 +757,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -660,7 +771,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -711,7 +824,11 @@
 			"module": "@base-ui/react/button",
 			"name": "Button",
 			"weight": 1,
-			"props": ["type", "$small", "..."],
+			"props": [
+				"type",
+				"$small",
+				"..."
+			],
 			"instances": 6
 		},
 		{
@@ -723,7 +840,11 @@
 			"module": "src/components/Icon/Icon.tsx",
 			"name": "Icon",
 			"weight": 1,
-			"props": ["name", "size", "color"],
+			"props": [
+				"name",
+				"size",
+				"color"
+			],
 			"instances": 6
 		},
 		{
@@ -735,7 +856,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 45
 		},
 		{
@@ -747,7 +870,10 @@
 			"module": "@base-ui/react/dialog",
 			"name": "Dialog.Root",
 			"weight": 1,
-			"props": ["open", "onOpenChange"],
+			"props": [
+				"open",
+				"onOpenChange"
+			],
 			"instances": 1
 		},
 		{
@@ -759,7 +885,9 @@
 			"module": "@base-ui/react/dialog",
 			"name": "Dialog.Portal",
 			"weight": 1,
-			"props": ["container"],
+			"props": [
+				"container"
+			],
 			"instances": 1
 		},
 		{
@@ -771,7 +899,9 @@
 			"module": "@base-ui/react/dialog",
 			"name": "Dialog.Backdrop",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 1
 		},
 		{
@@ -783,7 +913,12 @@
 			"module": "@base-ui/react/dialog",
 			"name": "Dialog.Popup",
 			"weight": 1,
-			"props": ["ref", "initialFocus", "data-testid", "aria-label"],
+			"props": [
+				"ref",
+				"initialFocus",
+				"data-testid",
+				"aria-label"
+			],
 			"instances": 1
 		},
 		{
@@ -795,7 +930,15 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["data-testid", "onClick", "clear", "round", "icon", "aria-label", "iconSize"],
+			"props": [
+				"data-testid",
+				"onClick",
+				"clear",
+				"round",
+				"icon",
+				"aria-label",
+				"iconSize"
+			],
 			"instances": 1
 		},
 		{
@@ -807,7 +950,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -819,7 +964,10 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -831,7 +979,10 @@
 			"module": "react-loading-skeleton",
 			"name": "SkeletonTheme",
 			"weight": 1,
-			"props": ["color", "highlightColor"],
+			"props": [
+				"color",
+				"highlightColor"
+			],
 			"instances": 3
 		},
 		{
@@ -843,7 +994,11 @@
 			"module": "react-loading-skeleton",
 			"name": "default",
 			"weight": 1,
-			"props": ["height", "width", "style"],
+			"props": [
+				"height",
+				"width",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -855,7 +1010,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -867,7 +1024,9 @@
 			"module": "react-loading-skeleton",
 			"name": "default",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -879,7 +1038,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -891,7 +1052,9 @@
 			"module": "react-loading-skeleton",
 			"name": "default",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -927,7 +1090,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -939,7 +1104,11 @@
 			"module": "react-loading-skeleton",
 			"name": "default",
 			"weight": 1,
-			"props": ["width", "height", "style"],
+			"props": [
+				"width",
+				"height",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -963,7 +1132,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1.5
 		},
 		{
@@ -975,7 +1146,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1.5
 		},
 		{
@@ -987,7 +1160,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1.5
 		},
 		{
@@ -999,7 +1174,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1.5
 		},
 		{
@@ -1011,7 +1188,10 @@
 			"module": "src/components/Badge/Badge.tsx",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1.5
 		},
 		{
@@ -1023,7 +1203,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1035,7 +1217,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1047,7 +1231,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -1059,7 +1245,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -1071,7 +1259,10 @@
 			"module": "src/components/Badge/Badge.tsx",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -1083,7 +1274,11 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type", "className"],
+			"props": [
+				"size",
+				"type",
+				"className"
+			],
 			"instances": 3.5
 		},
 		{
@@ -1095,7 +1290,10 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "$withMargin"],
+			"props": [
+				"level",
+				"$withMargin"
+			],
 			"instances": 2
 		},
 		{
@@ -1107,7 +1305,10 @@
 			"module": "src/components/ShoppingCart/ShoppingCartItem/ShoppingCartItem.tsx",
 			"name": "ShoppingCartItem",
 			"weight": 0.5,
-			"props": ["key", "item"],
+			"props": [
+				"key",
+				"item"
+			],
 			"instances": 1
 		},
 		{
@@ -1143,7 +1344,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 2
 		},
 		{
@@ -1155,7 +1358,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1167,7 +1372,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1179,7 +1386,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1191,7 +1400,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -1203,7 +1414,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -1215,7 +1428,11 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["disabled", "large", "onClick"],
+			"props": [
+				"disabled",
+				"large",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -1227,7 +1444,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 27
 		},
 		{
@@ -1263,7 +1483,12 @@
 			"module": "src/components/forms/Select.tsx",
 			"name": "Select",
 			"weight": 1,
-			"props": ["value", "onChange", "aria-label", "options"],
+			"props": [
+				"value",
+				"onChange",
+				"aria-label",
+				"options"
+			],
 			"instances": 27
 		},
 		{
@@ -1275,7 +1500,12 @@
 			"module": "src/components/Sidebar/Sidebar.tsx",
 			"name": "Sidebar",
 			"weight": 1,
-			"props": ["title", "onClose", "isOpen", "footer"],
+			"props": [
+				"title",
+				"onClose",
+				"isOpen",
+				"footer"
+			],
 			"instances": 27
 		},
 		{
@@ -1287,7 +1517,10 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": ["onClick", "totalPrice"],
+			"props": [
+				"onClick",
+				"totalPrice"
+			],
 			"instances": 27
 		},
 		{
@@ -1299,7 +1532,11 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "ShoppingCartMenuItem",
 			"weight": 1,
-			"props": ["key", "item", "onChange"],
+			"props": [
+				"key",
+				"item",
+				"onChange"
+			],
 			"instances": 27
 		},
 		{
@@ -1311,7 +1548,11 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Root",
 			"weight": 1,
-			"props": ["open", "swipeDirection", "onOpenChange"],
+			"props": [
+				"open",
+				"swipeDirection",
+				"onOpenChange"
+			],
 			"instances": 27
 		},
 		{
@@ -1323,7 +1564,9 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Portal",
 			"weight": 1,
-			"props": ["container"],
+			"props": [
+				"container"
+			],
 			"instances": 27
 		},
 		{
@@ -1335,7 +1578,9 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Backdrop",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 27
 		},
 		{
@@ -1359,7 +1604,9 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Popup",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 27
 		},
 		{
@@ -1371,7 +1618,10 @@
 			"module": "@base-ui/react/drawer",
 			"name": "Drawer.Title",
 			"weight": 1,
-			"props": ["className", "render"],
+			"props": [
+				"className",
+				"render"
+			],
 			"instances": 27
 		},
 		{
@@ -1383,7 +1633,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 27
 		},
 		{
@@ -1395,7 +1647,15 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "data-testid", "onClick", "clear", "round", "icon", "iconSize"],
+			"props": [
+				"aria-label",
+				"data-testid",
+				"onClick",
+				"clear",
+				"round",
+				"icon",
+				"iconSize"
+			],
 			"instances": 27
 		},
 		{
@@ -1407,7 +1667,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["$inverted"],
+			"props": [
+				"$inverted"
+			],
 			"instances": 4
 		},
 		{
@@ -1419,7 +1681,13 @@
 			"module": "@base-ui/react/input",
 			"name": "Input",
 			"weight": 1,
-			"props": ["id", "type", "className", "...", "autoComplete"],
+			"props": [
+				"id",
+				"type",
+				"className",
+				"...",
+				"autoComplete"
+			],
 			"instances": 7
 		},
 		{
@@ -1431,7 +1699,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "htmlFor"],
+			"props": [
+				"type",
+				"htmlFor"
+			],
 			"instances": 27
 		},
 		{
@@ -1479,7 +1750,11 @@
 			"module": "src/components/TopBanner/TopBanner.tsx",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "photoUrl", "onBackClick"],
+			"props": [
+				"title",
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1491,7 +1766,9 @@
 			"module": "src/components/Breadcrumb/Breadcrumb.tsx",
 			"name": "Breadcrumb",
 			"weight": 1,
-			"props": ["items"],
+			"props": [
+				"items"
+			],
 			"instances": 1
 		},
 		{
@@ -1503,7 +1780,13 @@
 			"module": "src/components/ErrorBlock/ErrorBlock.tsx",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["body", "title", "image", "buttonText", "onButtonClick"],
+			"props": [
+				"body",
+				"title",
+				"image",
+				"buttonText",
+				"onButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1515,7 +1798,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1527,7 +1812,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1551,7 +1840,10 @@
 			"module": "src/components/TopBanner/TopBanner.tsx",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "onBackClick"],
+			"props": [
+				"title",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1563,7 +1855,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1587,7 +1881,9 @@
 			"module": "src/pages/CategoryListPage/components/CategoryList/CategoryList.tsx",
 			"name": "CategoryList",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1599,7 +1895,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1611,7 +1910,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["...", "title"],
+			"props": [
+				"...",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1623,7 +1925,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1635,7 +1939,10 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "className"],
+			"props": [
+				"level",
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1659,7 +1966,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -1671,7 +1980,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1683,7 +1999,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1695,7 +2018,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "type", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"type",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1707,7 +2038,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "type", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"type",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1719,7 +2058,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1731,7 +2073,9 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1743,7 +2087,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1755,7 +2106,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1767,7 +2125,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1779,7 +2144,10 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1791,7 +2159,9 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1803,7 +2173,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/ContactDetails.tsx",
 			"name": "ContactDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onNext"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onNext"
+			],
 			"instances": 1
 		},
 		{
@@ -1815,7 +2189,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/DeliveryDetails.tsx",
 			"name": "DeliveryDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onPrevious"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onPrevious"
+			],
 			"instances": 1
 		},
 		{
@@ -1827,7 +2205,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/StepIndicator.tsx",
 			"name": "StepIndicator",
 			"weight": 1,
-			"props": ["title", "currentStep", "amountOfSteps"],
+			"props": [
+				"title",
+				"currentStep",
+				"amountOfSteps"
+			],
 			"instances": 1
 		},
 		{
@@ -1839,7 +2221,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1851,7 +2235,10 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1887,7 +2274,9 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.tsx",
 			"name": "RestaurantsSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1911,7 +2300,9 @@
 			"module": "src/pages/HomePage/components/CategoriesSection/CategoriesSection.tsx",
 			"name": "CategoriesSection",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1923,7 +2314,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["className"],
+			"props": [
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1947,7 +2340,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1971,7 +2366,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1983,7 +2380,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -2007,7 +2406,11 @@
 			"module": "src/components/PageSection/PageSection.tsx",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title", "topButtonLabel", "onTopButtonClick"],
+			"props": [
+				"title",
+				"topButtonLabel",
+				"onTopButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2019,7 +2422,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -2031,7 +2437,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -2043,7 +2452,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["round", "..."],
+			"props": [
+				"round",
+				"..."
+			],
 			"instances": 1
 		},
 		{
@@ -2055,7 +2467,9 @@
 			"module": "src/components/PageSection/PageSection.tsx",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2067,7 +2481,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -2079,7 +2496,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -2091,7 +2510,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -2103,7 +2526,12 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.container.tsx",
 			"name": "RestaurantsSectionComponent",
 			"weight": 1,
-			"props": ["title", "restaurants", "isLoading", "onRestaurantClick"],
+			"props": [
+				"title",
+				"restaurants",
+				"isLoading",
+				"onRestaurantClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2115,7 +2543,9 @@
 			"module": "src/components/PageSection/PageSection.tsx",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2127,7 +2557,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -2139,7 +2572,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -2151,7 +2586,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -2163,7 +2602,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2175,7 +2616,13 @@
 			"module": "src/components/ErrorBlock/ErrorBlock.tsx",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "image", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"image",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -2187,7 +2634,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -2199,7 +2648,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2211,7 +2662,13 @@
 			"module": "src/components/ErrorBlock/ErrorBlock.tsx",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "image", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"image",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -2223,7 +2680,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -2235,7 +2694,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2259,7 +2720,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2271,7 +2734,13 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItemModal/FoodItemModal.tsx",
 			"name": "FoodItemModal",
 			"weight": 1,
-			"props": ["item", "cartItems", "onClose", "onItemSave", "onItemRemove"],
+			"props": [
+				"item",
+				"cartItems",
+				"onClose",
+				"onItemSave",
+				"onItemRemove"
+			],
 			"instances": 1
 		},
 		{
@@ -2283,7 +2752,10 @@
 			"module": "src/components/TopBanner/TopBanner.tsx",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["photoUrl", "onBackClick"],
+			"props": [
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2295,7 +2767,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2319,7 +2793,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -2331,7 +2807,10 @@
 			"module": "src/components/Badge/Badge.tsx",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -2343,7 +2822,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2355,7 +2839,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2367,7 +2856,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2379,7 +2873,11 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["aria-label", "type", "fontWeight"],
+			"props": [
+				"aria-label",
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -2391,7 +2889,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2427,7 +2927,10 @@
 			"module": "src/components/Modal/Modal.tsx",
 			"name": "Modal",
 			"weight": 1,
-			"props": ["isOpen", "onClose"],
+			"props": [
+				"isOpen",
+				"onClose"
+			],
 			"instances": 1
 		},
 		{
@@ -2463,7 +2966,14 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "round", "clear", "icon", "onClick", "disabled"],
+			"props": [
+				"aria-label",
+				"round",
+				"clear",
+				"icon",
+				"onClick",
+				"disabled"
+			],
 			"instances": 1
 		},
 		{
@@ -2475,7 +2985,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2487,7 +2999,14 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "round", "clear", "icon", "onClick", "disabled"],
+			"props": [
+				"aria-label",
+				"round",
+				"clear",
+				"icon",
+				"onClick",
+				"disabled"
+			],
 			"instances": 1
 		},
 		{
@@ -2499,7 +3018,10 @@
 			"module": "src/components/Button/Button.tsx",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "onClick"],
+			"props": [
+				"aria-label",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2511,7 +3033,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2523,7 +3047,14 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItem/FoodItem.tsx",
 			"name": "FoodItem",
 			"weight": 1,
-			"props": ["key", "name", "price", "description", "quantity", "onClick"],
+			"props": [
+				"key",
+				"name",
+				"price",
+				"description",
+				"quantity",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2535,7 +3066,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2547,7 +3080,9 @@
 			"module": "src/components/TopBanner/TopBanner.tsx",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2559,7 +3094,9 @@
 			"module": "src/components/typography/Body.tsx",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2571,7 +3108,9 @@
 			"module": "src/components/typography/Heading.tsx",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2583,7 +3122,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -2595,7 +3136,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": ["sticky"],
+			"props": [
+				"sticky"
+			],
 			"instances": 9
 		},
 		{
@@ -2619,7 +3162,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "HeaderComponent",
 			"weight": 1,
-			"props": ["logoOnly"],
+			"props": [
+				"logoOnly"
+			],
 			"instances": 9
 		},
 		{

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
@@ -12,8 +12,7 @@
 			"module": "react-router-dom",
 			"name": "BrowserRouter",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]",
@@ -26,8 +25,7 @@
 			"weight": 1,
 			"props": [
 				"store"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/GlobalStyle[0]",
@@ -38,8 +36,7 @@
 			"module": "styled-components",
 			"name": "createGlobalStyle",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/AppRoutes[1]",
@@ -50,8 +47,7 @@
 			"module": "src/Routes.tsx",
 			"name": "AppRoutes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]",
@@ -62,8 +58,7 @@
 			"module": "react-router-dom",
 			"name": "Routes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[0]",
@@ -77,8 +72,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryListPage[0]",
@@ -89,8 +83,7 @@
 			"module": "src/pages/CategoryListPage/CategoryListPage.tsx",
 			"name": "CategoryListPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[1]",
@@ -104,8 +97,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryDetailPage[0]",
@@ -116,8 +108,7 @@
 			"module": "src/pages/CategoryDetailPage/CategoryDetailPage.tsx",
 			"name": "CategoryDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[2]",
@@ -131,8 +122,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/RestaurantDetailPage[0]",
@@ -143,8 +133,7 @@
 			"module": "src/pages/RestaurantDetailPage/RestaurantDetailPage.tsx",
 			"name": "RestaurantDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[3]",
@@ -158,8 +147,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CheckoutPage[0]",
@@ -170,8 +158,7 @@
 			"module": "src/pages/CheckoutPage/CheckoutPage.tsx",
 			"name": "CheckoutPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[4]",
@@ -185,8 +172,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/SuccessPage[0]",
@@ -197,8 +183,7 @@
 			"module": "src/pages/SuccessPage/SuccessPage.tsx",
 			"name": "SuccessPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[5]",
@@ -212,8 +197,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/HomePage[0]",
@@ -224,8 +208,7 @@
 			"module": "src/pages/HomePage/HomePage.tsx",
 			"name": "HomePage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AnimatedIllustration/span[0]/Lottie[0]",
@@ -241,8 +224,7 @@
 				"play",
 				"loop",
 				"animationData"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]",
@@ -255,8 +237,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]/Title[1]",
@@ -269,8 +250,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Squared/SquaredContainer[0]/FloatingTitle[1]/Body[0]",
@@ -284,8 +264,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Rounded[0]",
@@ -299,8 +278,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Squared[0]",
@@ -314,8 +292,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]",
@@ -326,8 +303,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/Logo[0]",
@@ -341,8 +317,7 @@
 			"props": [
 				"large",
 				"logoOnly"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[1]",
@@ -356,8 +331,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[2]",
@@ -371,8 +345,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[3]",
@@ -385,8 +358,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "FooterCard/StyledFooterCard[0]",
@@ -401,8 +373,7 @@
 				"title",
 				"links",
 				"..."
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "render/RouterLink[0]",
@@ -415,8 +386,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -434,8 +404,7 @@
 				"icon",
 				"onClick",
 				"..."
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -449,8 +418,7 @@
 			"props": [
 				"to",
 				"aria-label"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]/Logo[0]",
@@ -461,8 +429,7 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/ThemeToggle[0]",
@@ -473,8 +440,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]",
@@ -488,8 +454,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]/Button[0]",
@@ -502,8 +467,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]",
@@ -517,8 +481,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]/Button[0]",
@@ -531,8 +494,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/Button[1]",
@@ -547,8 +509,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/CartLabel[0]/CartText[0]",
@@ -561,8 +522,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/CartLabel[0]/CartTotal[1]",
@@ -575,8 +535,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/ShoppingCartMenu[0]",
@@ -594,8 +553,7 @@
 				"cartItems",
 				"totalPrice",
 				"onItemChange"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Header/HeaderComponent[0]",
@@ -614,8 +572,7 @@
 				"toggleCartVisibility",
 				"totalPrice",
 				"saveItem"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Link/DsLink[0]",
@@ -629,8 +586,7 @@
 			"props": [
 				"render",
 				"..."
-			],
-			"instances": 14
+			]
 		},
 		{
 			"path": "Link/RouterLink[0]",
@@ -643,8 +599,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 14
+			]
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -658,8 +613,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 12
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]",
@@ -674,8 +628,7 @@
 				"data-testid",
 				"role",
 				"aria-label"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/Skeleton[0]",
@@ -689,8 +642,7 @@
 			"props": [
 				"height",
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]",
@@ -705,8 +657,7 @@
 				"aria-hidden",
 				"level",
 				"size"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]/Skeleton[0]",
@@ -719,8 +670,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[1]",
@@ -733,8 +683,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[1]/Skeleton[0]",
@@ -747,8 +696,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Description[2]",
@@ -759,8 +707,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Description[2]/Skeleton[0]",
@@ -771,8 +718,7 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[3]",
@@ -785,8 +731,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[3]/Skeleton[0]",
@@ -801,8 +746,7 @@
 				"width",
 				"height",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCard/RestaurantCardSkeleton[0]",
@@ -813,8 +757,7 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 1.5
+			"props": []
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]",
@@ -830,8 +773,7 @@
 				"className",
 				"data-testid",
 				"onClick"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/NewBadge[0]",
@@ -845,8 +787,7 @@
 			"props": [
 				"text",
 				"variant"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Closed[0]/Body[0]",
@@ -859,8 +800,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]",
@@ -874,8 +814,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/Review[1]",
@@ -888,8 +827,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/Description[2]",
@@ -902,8 +840,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/StyledBadge[0]",
@@ -917,8 +854,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Body[0]",
@@ -931,8 +867,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Heading[0]",
@@ -945,8 +880,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Review[1]",
@@ -959,8 +893,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Body[2]",
@@ -973,8 +906,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/Badge[0]",
@@ -988,8 +920,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]",
@@ -1000,8 +931,7 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/StyledHeading[0]",
@@ -1016,8 +946,7 @@
 				"level",
 				"size",
 				"$withMargin"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "OrderSummary/ShoppingCartItem[0]",
@@ -1031,8 +960,7 @@
 			"props": [
 				"key",
 				"item"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/Body[0]",
@@ -1043,8 +971,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 0.5,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/Body[0]",
@@ -1055,8 +982,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/TotalHeading[1]",
@@ -1070,8 +996,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Quantity[0]",
@@ -1084,8 +1009,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Name[1]",
@@ -1098,8 +1022,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Price[2]",
@@ -1112,8 +1035,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[0]",
@@ -1126,8 +1048,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[1]",
@@ -1140,8 +1061,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Button[1]",
@@ -1156,8 +1076,7 @@
 				"disabled",
 				"large",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[0]",
@@ -1171,8 +1090,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[1]",
@@ -1183,8 +1101,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[2]",
@@ -1195,8 +1112,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/Select[1]",
@@ -1212,8 +1128,7 @@
 				"onChange",
 				"aria-label",
 				"options"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Sidebar[0]",
@@ -1230,8 +1145,7 @@
 				"isOpen",
 				"container",
 				"footer"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Footer[0]",
@@ -1245,8 +1159,7 @@
 			"props": [
 				"onClick",
 				"totalPrice"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/ShoppingCartMenuItem[0]",
@@ -1261,8 +1174,7 @@
 				"key",
 				"item",
 				"onChange"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "<module>/StrictMode[0]",
@@ -1273,8 +1185,7 @@
 			"module": "react",
 			"name": "StrictMode",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "<module>/StrictMode[0]/App[0]",
@@ -1285,8 +1196,7 @@
 			"module": "src/App.tsx",
 			"name": "App",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]",
@@ -1297,8 +1207,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/TopBanner[0]",
@@ -1313,8 +1222,7 @@
 				"title",
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/Container[1]",
@@ -1325,8 +1233,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/Container[1]/Breadcrumb[0]",
@@ -1339,8 +1246,7 @@
 			"weight": 1,
 			"props": [
 				"items"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "render/Link[0]",
@@ -1353,8 +1259,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/ErrorBlock[0]",
@@ -1371,8 +1276,7 @@
 				"illustration",
 				"buttonText",
 				"onButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCardSkeleton[0]",
@@ -1385,8 +1289,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCard[0]",
@@ -1401,8 +1304,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]",
@@ -1413,8 +1315,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/TopBanner[0]",
@@ -1428,8 +1329,7 @@
 			"props": [
 				"title",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]",
@@ -1440,8 +1340,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/StyledHeading[0]",
@@ -1454,8 +1353,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/StyledBody[1]",
@@ -1466,8 +1364,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/CategoryList[2]",
@@ -1480,8 +1377,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]",
@@ -1495,8 +1391,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]/Category[0]",
@@ -1510,8 +1405,7 @@
 			"props": [
 				"...",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]",
@@ -1524,8 +1418,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/TopContainer[0]/StyledHeading[0]",
@@ -1539,8 +1432,7 @@
 			"props": [
 				"level",
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]",
@@ -1551,8 +1443,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/MultiStepForm[0]",
@@ -1563,8 +1454,7 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/MultiStepForm.tsx",
 			"name": "MultiStepForm",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/OrderDetailsContainer[1]/OrderSummary[0]",
@@ -1577,8 +1467,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[0]",
@@ -1596,8 +1485,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[1]",
@@ -1615,8 +1503,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[2]",
@@ -1635,8 +1522,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[3]",
@@ -1655,8 +1541,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/DisclaimerText[4]",
@@ -1670,8 +1555,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/div[5]/Button[0]",
@@ -1684,8 +1568,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[0]",
@@ -1703,8 +1586,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[1]",
@@ -1722,8 +1604,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[2]",
@@ -1741,8 +1622,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[0]",
@@ -1756,8 +1636,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[1]",
@@ -1770,8 +1649,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/ContactDetails[0]",
@@ -1786,8 +1664,7 @@
 				"formData",
 				"setFormData",
 				"onNext"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/DeliveryDetails[0]",
@@ -1802,8 +1679,7 @@
 				"formData",
 				"setFormData",
 				"onPrevious"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "MultiStepForm/FormContainer[0]/StepIndicator[0]",
@@ -1818,8 +1694,7 @@
 				"title",
 				"currentStep",
 				"amountOfSteps"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Heading[0]",
@@ -1833,8 +1708,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Body[1]",
@@ -1848,8 +1722,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]",
@@ -1860,8 +1733,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/Banner[0]",
@@ -1872,8 +1744,7 @@
 			"module": "src/pages/HomePage/components/Banner/Banner.tsx",
 			"name": "Banner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/RestaurantsSection[2]",
@@ -1886,8 +1757,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/AwardWinningSection[4]",
@@ -1898,8 +1768,7 @@
 			"module": "src/pages/HomePage/components/AwardWinningSection/AwardWinningSection.tsx",
 			"name": "AwardWinningSection",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/CategoriesSection[6]",
@@ -1912,8 +1781,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]",
@@ -1924,8 +1792,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[0]",
@@ -1938,8 +1805,7 @@
 			"weight": 1,
 			"props": [
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[1]",
@@ -1950,8 +1816,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]",
@@ -1964,8 +1829,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]/StyledButton[0]",
@@ -1976,8 +1840,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/StyledHeading[0]",
@@ -1990,8 +1853,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]",
@@ -2004,8 +1866,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]/Button[0]",
@@ -2016,8 +1877,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]",
@@ -2032,8 +1892,7 @@
 				"title",
 				"topButtonLabel",
 				"onTopButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]/Carousel[0]",
@@ -2047,8 +1906,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]",
@@ -2062,8 +1920,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]/Category[0]",
@@ -2077,8 +1934,7 @@
 			"props": [
 				"round",
 				"..."
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]",
@@ -2091,8 +1947,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]/Carousel[0]",
@@ -2106,8 +1961,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCardSkeleton[0]",
@@ -2120,8 +1974,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCard[0]",
@@ -2136,8 +1989,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantsSectionComponent[0]",
@@ -2153,8 +2005,7 @@
 				"restaurants",
 				"isLoading",
 				"onRestaurantClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]",
@@ -2167,8 +2018,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]/Carousel[0]",
@@ -2182,8 +2032,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCardSkeleton[0]",
@@ -2196,8 +2045,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCard[0]",
@@ -2212,8 +2060,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]",
@@ -2226,8 +2073,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]",
@@ -2244,8 +2090,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]",
@@ -2258,8 +2103,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#2",
@@ -2272,8 +2116,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]#2",
@@ -2290,8 +2133,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]#2",
@@ -2304,8 +2146,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#3",
@@ -2318,8 +2159,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/SpinnerContainer[0]/Spinner[0]",
@@ -2330,8 +2170,7 @@
 			"module": "@droppy/design-system",
 			"name": "Spinner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#4",
@@ -2344,8 +2183,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/FoodItemModal[0]",
@@ -2362,8 +2200,7 @@
 				"onClose",
 				"onItemSave",
 				"onItemRemove"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/TopBanner[1]",
@@ -2377,8 +2214,7 @@
 			"props": [
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]",
@@ -2389,8 +2225,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/Heading[0]",
@@ -2403,8 +2238,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/Body[1]",
@@ -2415,8 +2249,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/Review[2]",
@@ -2429,8 +2262,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/StyledBadge[0]",
@@ -2444,8 +2276,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/MenuSection[3]/Container[0]",
@@ -2456,8 +2287,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]",
@@ -2473,8 +2303,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#2",
@@ -2490,8 +2319,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#3",
@@ -2507,8 +2335,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]",
@@ -2521,8 +2348,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Quantity[0]",
@@ -2537,8 +2363,7 @@
 				"aria-label",
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Heading[0]",
@@ -2551,8 +2376,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Description[1]",
@@ -2563,8 +2387,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Price[2]",
@@ -2575,8 +2398,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/Modal[0]",
@@ -2591,8 +2413,7 @@
 				"isOpen",
 				"onClose",
 				"container"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/Heading[0]",
@@ -2603,8 +2424,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/StyledBody[1]",
@@ -2615,8 +2435,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/QuantityStepper[0]",
@@ -2632,8 +2451,7 @@
 				"onChange",
 				"min",
 				"max"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/StyledButton[1]",
@@ -2647,8 +2465,7 @@
 			"props": [
 				"aria-label",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodSection/div[0]/StyledHeading[0]",
@@ -2661,8 +2478,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodSection/FoodItem[0]",
@@ -2680,8 +2496,7 @@
 				"description",
 				"quantity",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]",
@@ -2694,8 +2509,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/TopBanner[0]",
@@ -2708,8 +2522,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/Body[0]",
@@ -2722,8 +2535,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/StyledHeading[1]",
@@ -2736,8 +2548,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/OrderSummary[2]",
@@ -2750,8 +2561,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "default/Header[0]",
@@ -2762,8 +2572,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "headers/Header[0]",
@@ -2776,8 +2585,7 @@
 			"weight": 1,
 			"props": [
 				"sticky"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "basic/HeaderComponent[0]",
@@ -2790,8 +2598,7 @@
 			"weight": 1,
 			"props": [
 				"logoOnly"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageTemplate/DsPageTemplate[0]",
@@ -2806,8 +2613,7 @@
 				"header",
 				"footer",
 				"..."
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2818,8 +2624,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
@@ -24,7 +24,9 @@
 			"module": "react-redux",
 			"name": "Provider",
 			"weight": 1,
-			"props": ["store"],
+			"props": [
+				"store"
+			],
 			"instances": 1
 		},
 		{
@@ -72,7 +74,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -96,7 +101,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -120,7 +128,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -144,7 +155,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -168,7 +182,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -192,7 +209,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -216,7 +236,12 @@
 			"module": "react-lottie-player",
 			"name": "default",
 			"weight": 1,
-			"props": ["style", "play", "loop", "animationData"],
+			"props": [
+				"style",
+				"play",
+				"loop",
+				"animationData"
+			],
 			"instances": 2
 		},
 		{
@@ -228,7 +253,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 1
 		},
 		{
@@ -240,7 +267,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -252,7 +281,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -264,7 +296,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Rounded",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -276,7 +311,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Squared",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -289,7 +327,7 @@
 			"name": "Container",
 			"weight": 1,
 			"props": [],
-			"instances": 1
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/Logo[0]",
@@ -300,8 +338,11 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": ["large", "logoOnly"],
-			"instances": 1
+			"props": [
+				"large",
+				"logoOnly"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[1]",
@@ -312,8 +353,11 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
-			"instances": 1
+			"props": [
+				"title",
+				"links"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[2]",
@@ -324,8 +368,11 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
-			"instances": 1
+			"props": [
+				"title",
+				"links"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[3]",
@@ -336,8 +383,10 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title"],
-			"instances": 1
+			"props": [
+				"title"
+			],
+			"instances": 9
 		},
 		{
 			"path": "FooterCard/StyledFooterCard[0]",
@@ -348,8 +397,12 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links", "..."],
-			"instances": 1
+			"props": [
+				"title",
+				"links",
+				"..."
+			],
+			"instances": 27
 		},
 		{
 			"path": "render/RouterLink[0]",
@@ -360,8 +413,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
-			"instances": 1
+			"props": [
+				"to"
+			],
+			"instances": 27
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -372,8 +427,15 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["round", "clear", "aria-label", "icon", "onClick", "..."],
-			"instances": 1
+			"props": [
+				"round",
+				"clear",
+				"aria-label",
+				"icon",
+				"onClick",
+				"..."
+			],
+			"instances": 3
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -384,7 +446,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "aria-label"],
+			"props": [
+				"to",
+				"aria-label"
+			],
 			"instances": 3
 		},
 		{
@@ -420,7 +485,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 3
 		},
 		{
@@ -432,7 +500,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 3
 		},
 		{
@@ -444,7 +514,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 3
 		},
 		{
@@ -456,7 +529,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 3
 		},
 		{
@@ -468,7 +543,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "icon", "onClick"],
+			"props": [
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -480,7 +559,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -492,7 +573,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -543,8 +626,11 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["render", "..."],
-			"instances": 1
+			"props": [
+				"render",
+				"..."
+			],
+			"instances": 14
 		},
 		{
 			"path": "Link/RouterLink[0]",
@@ -555,8 +641,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
-			"instances": 1
+			"props": [
+				"to"
+			],
+			"instances": 14
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -567,8 +655,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
-			"instances": 4
+			"props": [
+				"level",
+				"size"
+			],
+			"instances": 12
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]",
@@ -579,7 +670,11 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid", "role", "aria-label"],
+			"props": [
+				"data-testid",
+				"role",
+				"aria-label"
+			],
 			"instances": 3
 		},
 		{
@@ -591,7 +686,10 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["height", "width"],
+			"props": [
+				"height",
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -603,7 +701,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["aria-hidden", "level", "size"],
+			"props": [
+				"aria-hidden",
+				"level",
+				"size"
+			],
 			"instances": 3
 		},
 		{
@@ -615,7 +717,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -627,7 +731,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -639,7 +745,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -675,7 +783,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -687,7 +797,11 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width", "height", "style"],
+			"props": [
+				"width",
+				"height",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -711,7 +825,12 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["interactive", "className", "data-testid", "onClick"],
+			"props": [
+				"interactive",
+				"className",
+				"data-testid",
+				"onClick"
+			],
 			"instances": 1.5
 		},
 		{
@@ -723,7 +842,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["text", "variant"],
+			"props": [
+				"text",
+				"variant"
+			],
 			"instances": 1.5
 		},
 		{
@@ -735,7 +857,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1.5
 		},
 		{
@@ -747,7 +871,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1.5
 		},
 		{
@@ -759,7 +886,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1.5
 		},
 		{
@@ -771,7 +900,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1.5
 		},
 		{
@@ -783,7 +914,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1.5
 		},
 		{
@@ -795,7 +929,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -807,7 +943,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -819,7 +957,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -831,7 +971,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -843,7 +985,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -867,7 +1012,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size", "$withMargin"],
+			"props": [
+				"level",
+				"size",
+				"$withMargin"
+			],
 			"instances": 2
 		},
 		{
@@ -879,7 +1028,10 @@
 			"module": "src/components/ShoppingCart/ShoppingCartItem/ShoppingCartItem.tsx",
 			"name": "ShoppingCartItem",
 			"weight": 0.5,
-			"props": ["key", "item"],
+			"props": [
+				"key",
+				"item"
+			],
 			"instances": 1
 		},
 		{
@@ -915,7 +1067,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 2
 		},
 		{
@@ -927,7 +1082,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -939,7 +1096,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -951,7 +1110,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -963,7 +1124,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -975,7 +1138,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -987,7 +1152,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["disabled", "large", "onClick"],
+			"props": [
+				"disabled",
+				"large",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -999,7 +1168,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -1035,7 +1207,12 @@
 			"module": "@droppy/design-system",
 			"name": "Select",
 			"weight": 1,
-			"props": ["value", "onChange", "aria-label", "options"],
+			"props": [
+				"value",
+				"onChange",
+				"aria-label",
+				"options"
+			],
 			"instances": 3
 		},
 		{
@@ -1047,7 +1224,13 @@
 			"module": "@droppy/design-system",
 			"name": "Sidebar",
 			"weight": 1,
-			"props": ["title", "onClose", "isOpen", "container", "footer"],
+			"props": [
+				"title",
+				"onClose",
+				"isOpen",
+				"container",
+				"footer"
+			],
 			"instances": 3
 		},
 		{
@@ -1059,7 +1242,10 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": ["onClick", "totalPrice"],
+			"props": [
+				"onClick",
+				"totalPrice"
+			],
 			"instances": 3
 		},
 		{
@@ -1071,7 +1257,11 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "ShoppingCartMenuItem",
 			"weight": 1,
-			"props": ["key", "item", "onChange"],
+			"props": [
+				"key",
+				"item",
+				"onChange"
+			],
 			"instances": 3
 		},
 		{
@@ -1119,7 +1309,11 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "photoUrl", "onBackClick"],
+			"props": [
+				"title",
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1143,7 +1337,9 @@
 			"module": "@droppy/design-system",
 			"name": "Breadcrumb",
 			"weight": 1,
-			"props": ["items"],
+			"props": [
+				"items"
+			],
 			"instances": 1
 		},
 		{
@@ -1155,7 +1351,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1167,7 +1365,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["body", "title", "illustration", "buttonText", "onButtonClick"],
+			"props": [
+				"body",
+				"title",
+				"illustration",
+				"buttonText",
+				"onButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1179,7 +1383,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1191,7 +1397,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1215,7 +1425,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "onBackClick"],
+			"props": [
+				"title",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1239,7 +1452,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1263,7 +1478,9 @@
 			"module": "src/pages/CategoryListPage/components/CategoryList/CategoryList.tsx",
 			"name": "CategoryList",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1275,7 +1492,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1287,7 +1507,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["...", "title"],
+			"props": [
+				"...",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1299,7 +1522,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1311,7 +1536,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "className"],
+			"props": [
+				"level",
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1347,7 +1575,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -1359,7 +1589,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1371,7 +1608,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1383,7 +1627,15 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "type", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"type",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1395,7 +1647,15 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "type", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"type",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1407,7 +1667,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1419,7 +1682,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1431,7 +1696,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1443,7 +1715,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1455,7 +1734,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1467,7 +1753,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1479,7 +1768,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1491,7 +1782,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/ContactDetails.tsx",
 			"name": "ContactDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onNext"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onNext"
+			],
 			"instances": 1
 		},
 		{
@@ -1503,7 +1798,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/DeliveryDetails.tsx",
 			"name": "DeliveryDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onPrevious"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onPrevious"
+			],
 			"instances": 1
 		},
 		{
@@ -1515,7 +1814,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/StepIndicator.tsx",
 			"name": "StepIndicator",
 			"weight": 1,
-			"props": ["title", "currentStep", "amountOfSteps"],
+			"props": [
+				"title",
+				"currentStep",
+				"amountOfSteps"
+			],
 			"instances": 1
 		},
 		{
@@ -1527,7 +1830,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1
 		},
 		{
@@ -1539,7 +1845,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1575,7 +1884,9 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.tsx",
 			"name": "RestaurantsSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1599,7 +1910,9 @@
 			"module": "src/pages/HomePage/components/CategoriesSection/CategoriesSection.tsx",
 			"name": "CategoriesSection",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1623,7 +1936,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["className"],
+			"props": [
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1647,7 +1962,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1671,7 +1988,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1683,7 +2002,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1707,7 +2028,11 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title", "topButtonLabel", "onTopButtonClick"],
+			"props": [
+				"title",
+				"topButtonLabel",
+				"onTopButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1719,7 +2044,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1731,7 +2059,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1743,7 +2074,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["round", "..."],
+			"props": [
+				"round",
+				"..."
+			],
 			"instances": 1
 		},
 		{
@@ -1755,7 +2089,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1767,7 +2103,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1779,7 +2118,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1791,7 +2132,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1803,7 +2148,12 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.container.tsx",
 			"name": "RestaurantsSectionComponent",
 			"weight": 1,
-			"props": ["title", "restaurants", "isLoading", "onRestaurantClick"],
+			"props": [
+				"title",
+				"restaurants",
+				"isLoading",
+				"onRestaurantClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1815,7 +2165,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1827,7 +2179,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1839,7 +2194,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1851,7 +2208,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1863,7 +2224,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1875,7 +2238,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1887,7 +2256,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1899,7 +2270,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1911,7 +2284,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1923,7 +2302,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1935,7 +2316,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1959,7 +2342,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1971,7 +2356,13 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItemModal/FoodItemModal.tsx",
 			"name": "FoodItemModal",
 			"weight": 1,
-			"props": ["item", "cartItems", "onClose", "onItemSave", "onItemRemove"],
+			"props": [
+				"item",
+				"cartItems",
+				"onClose",
+				"onItemSave",
+				"onItemRemove"
+			],
 			"instances": 1
 		},
 		{
@@ -1983,7 +2374,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["photoUrl", "onBackClick"],
+			"props": [
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2007,7 +2401,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2031,7 +2427,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -2043,7 +2441,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -2067,7 +2468,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2079,7 +2485,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2091,7 +2502,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2103,7 +2519,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2115,7 +2533,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["aria-label", "type", "fontWeight"],
+			"props": [
+				"aria-label",
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -2127,7 +2549,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2163,7 +2587,11 @@
 			"module": "@droppy/design-system",
 			"name": "Modal",
 			"weight": 1,
-			"props": ["isOpen", "onClose", "container"],
+			"props": [
+				"isOpen",
+				"onClose",
+				"container"
+			],
 			"instances": 1
 		},
 		{
@@ -2199,7 +2627,12 @@
 			"module": "@droppy/design-system",
 			"name": "QuantityStepper",
 			"weight": 1,
-			"props": ["value", "onChange", "min", "max"],
+			"props": [
+				"value",
+				"onChange",
+				"min",
+				"max"
+			],
 			"instances": 1
 		},
 		{
@@ -2211,7 +2644,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "onClick"],
+			"props": [
+				"aria-label",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2223,7 +2659,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2235,7 +2673,14 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItem/FoodItem.tsx",
 			"name": "FoodItem",
 			"weight": 1,
-			"props": ["key", "name", "price", "description", "quantity", "onClick"],
+			"props": [
+				"key",
+				"name",
+				"price",
+				"description",
+				"quantity",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2247,7 +2692,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2259,7 +2706,9 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2271,7 +2720,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2283,7 +2734,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2295,7 +2748,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -2319,7 +2774,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": ["sticky"],
+			"props": [
+				"sticky"
+			],
 			"instances": 1
 		},
 		{
@@ -2331,7 +2788,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "HeaderComponent",
 			"weight": 1,
-			"props": ["logoOnly"],
+			"props": [
+				"logoOnly"
+			],
 			"instances": 1
 		},
 		{
@@ -2343,8 +2802,12 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["header", "footer", "..."],
-			"instances": 1
+			"props": [
+				"header",
+				"footer",
+				"..."
+			],
+			"instances": 9
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2356,7 +2819,7 @@
 			"name": "Footer",
 			"weight": 1,
 			"props": [],
-			"instances": 1
+			"instances": 9
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
@@ -24,7 +24,9 @@
 			"module": "react-redux",
 			"name": "Provider",
 			"weight": 1,
-			"props": ["store"],
+			"props": [
+				"store"
+			],
 			"instances": 1
 		},
 		{
@@ -72,7 +74,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -96,7 +101,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -120,7 +128,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -144,7 +155,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -168,7 +182,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -192,7 +209,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -216,7 +236,12 @@
 			"module": "react-lottie-player",
 			"name": "default",
 			"weight": 1,
-			"props": ["style", "play", "loop", "animationData"],
+			"props": [
+				"style",
+				"play",
+				"loop",
+				"animationData"
+			],
 			"instances": 2
 		},
 		{
@@ -228,7 +253,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 1
 		},
 		{
@@ -240,7 +267,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -252,7 +281,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -264,7 +296,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Rounded",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -276,7 +311,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Squared",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -289,7 +327,7 @@
 			"name": "Container",
 			"weight": 1,
 			"props": [],
-			"instances": 1
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/Logo[0]",
@@ -300,8 +338,11 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": ["large", "logoOnly"],
-			"instances": 1
+			"props": [
+				"large",
+				"logoOnly"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[1]",
@@ -312,8 +353,11 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
-			"instances": 1
+			"props": [
+				"title",
+				"links"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[2]",
@@ -324,8 +368,11 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
-			"instances": 1
+			"props": [
+				"title",
+				"links"
+			],
+			"instances": 9
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[3]",
@@ -336,8 +383,10 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title"],
-			"instances": 1
+			"props": [
+				"title"
+			],
+			"instances": 9
 		},
 		{
 			"path": "FooterCard/DsFooterCard[0]",
@@ -348,8 +397,12 @@
 			"module": "@droppy/design-system",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links", "..."],
-			"instances": 1
+			"props": [
+				"title",
+				"links",
+				"..."
+			],
+			"instances": 27
 		},
 		{
 			"path": "render/RouterLink[0]",
@@ -360,8 +413,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
-			"instances": 1
+			"props": [
+				"to"
+			],
+			"instances": 27
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -372,8 +427,15 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["round", "clear", "aria-label", "icon", "onClick", "..."],
-			"instances": 1
+			"props": [
+				"round",
+				"clear",
+				"aria-label",
+				"icon",
+				"onClick",
+				"..."
+			],
+			"instances": 3
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -384,7 +446,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "aria-label"],
+			"props": [
+				"to",
+				"aria-label"
+			],
 			"instances": 3
 		},
 		{
@@ -420,7 +485,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 3
 		},
 		{
@@ -432,7 +500,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 3
 		},
 		{
@@ -444,7 +514,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 3
 		},
 		{
@@ -456,7 +529,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 3
 		},
 		{
@@ -468,7 +543,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "icon", "onClick"],
+			"props": [
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -480,7 +559,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -492,7 +573,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -543,8 +626,11 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["render", "..."],
-			"instances": 1
+			"props": [
+				"render",
+				"..."
+			],
+			"instances": 14
 		},
 		{
 			"path": "Link/RouterLink[0]",
@@ -555,8 +641,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
-			"instances": 1
+			"props": [
+				"to"
+			],
+			"instances": 14
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -567,8 +655,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
-			"instances": 4
+			"props": [
+				"level",
+				"size"
+			],
+			"instances": 12
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]",
@@ -579,7 +670,11 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid", "role", "aria-label"],
+			"props": [
+				"data-testid",
+				"role",
+				"aria-label"
+			],
 			"instances": 3
 		},
 		{
@@ -591,7 +686,10 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["height", "width"],
+			"props": [
+				"height",
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -603,7 +701,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["aria-hidden", "level", "size"],
+			"props": [
+				"aria-hidden",
+				"level",
+				"size"
+			],
 			"instances": 3
 		},
 		{
@@ -615,7 +717,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -627,7 +731,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -639,7 +745,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -675,7 +783,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -687,7 +797,11 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width", "height", "style"],
+			"props": [
+				"width",
+				"height",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -711,7 +825,12 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["interactive", "className", "data-testid", "onClick"],
+			"props": [
+				"interactive",
+				"className",
+				"data-testid",
+				"onClick"
+			],
 			"instances": 1.5
 		},
 		{
@@ -723,7 +842,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1.5
 		},
 		{
@@ -735,7 +856,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1.5
 		},
 		{
@@ -747,7 +871,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1.5
 		},
 		{
@@ -759,7 +885,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1.5
 		},
 		{
@@ -771,7 +899,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1.5
 		},
 		{
@@ -783,7 +914,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -795,7 +928,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -807,7 +942,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -819,7 +956,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -831,7 +970,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -855,7 +997,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size", "$withMargin"],
+			"props": [
+				"level",
+				"size",
+				"$withMargin"
+			],
 			"instances": 2
 		},
 		{
@@ -867,7 +1013,10 @@
 			"module": "src/components/ShoppingCart/ShoppingCartItem/ShoppingCartItem.tsx",
 			"name": "ShoppingCartItem",
 			"weight": 0.5,
-			"props": ["key", "item"],
+			"props": [
+				"key",
+				"item"
+			],
 			"instances": 1
 		},
 		{
@@ -903,7 +1052,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 2
 		},
 		{
@@ -915,7 +1067,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -927,7 +1081,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -939,7 +1095,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -951,7 +1109,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -963,7 +1123,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -975,7 +1137,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["disabled", "large", "onClick"],
+			"props": [
+				"disabled",
+				"large",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -987,7 +1153,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -1023,7 +1192,12 @@
 			"module": "@droppy/design-system",
 			"name": "Select",
 			"weight": 1,
-			"props": ["value", "onChange", "aria-label", "options"],
+			"props": [
+				"value",
+				"onChange",
+				"aria-label",
+				"options"
+			],
 			"instances": 3
 		},
 		{
@@ -1035,7 +1209,13 @@
 			"module": "@droppy/design-system",
 			"name": "Sidebar",
 			"weight": 1,
-			"props": ["title", "onClose", "isOpen", "container", "footer"],
+			"props": [
+				"title",
+				"onClose",
+				"isOpen",
+				"container",
+				"footer"
+			],
 			"instances": 3
 		},
 		{
@@ -1047,7 +1227,10 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": ["onClick", "totalPrice"],
+			"props": [
+				"onClick",
+				"totalPrice"
+			],
 			"instances": 3
 		},
 		{
@@ -1059,7 +1242,11 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "ShoppingCartMenuItem",
 			"weight": 1,
-			"props": ["key", "item", "onChange"],
+			"props": [
+				"key",
+				"item",
+				"onChange"
+			],
 			"instances": 3
 		},
 		{
@@ -1107,7 +1294,11 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "photoUrl", "onBackClick"],
+			"props": [
+				"title",
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1131,7 +1322,9 @@
 			"module": "@droppy/design-system",
 			"name": "Breadcrumb",
 			"weight": 1,
-			"props": ["items"],
+			"props": [
+				"items"
+			],
 			"instances": 1
 		},
 		{
@@ -1143,7 +1336,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1155,7 +1350,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["body", "title", "illustration", "buttonText", "onButtonClick"],
+			"props": [
+				"body",
+				"title",
+				"illustration",
+				"buttonText",
+				"onButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1167,7 +1368,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1179,7 +1382,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1203,7 +1410,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "onBackClick"],
+			"props": [
+				"title",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1227,7 +1437,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1251,7 +1463,9 @@
 			"module": "src/pages/CategoryListPage/components/CategoryList/CategoryList.tsx",
 			"name": "CategoryList",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1263,7 +1477,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1275,7 +1492,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["...", "title"],
+			"props": [
+				"...",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1287,7 +1507,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1299,7 +1521,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "className"],
+			"props": [
+				"level",
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1335,7 +1560,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -1347,7 +1574,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1359,7 +1593,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1371,7 +1612,15 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "type", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"type",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1383,7 +1632,15 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "type", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"type",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1395,7 +1652,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1407,7 +1667,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1419,7 +1681,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1431,7 +1700,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1443,7 +1719,14 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1455,7 +1738,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1467,7 +1753,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1479,7 +1767,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/ContactDetails.tsx",
 			"name": "ContactDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onNext"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onNext"
+			],
 			"instances": 1
 		},
 		{
@@ -1491,7 +1783,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/DeliveryDetails.tsx",
 			"name": "DeliveryDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onPrevious"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onPrevious"
+			],
 			"instances": 1
 		},
 		{
@@ -1503,7 +1799,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/StepIndicator.tsx",
 			"name": "StepIndicator",
 			"weight": 1,
-			"props": ["title", "currentStep", "amountOfSteps"],
+			"props": [
+				"title",
+				"currentStep",
+				"amountOfSteps"
+			],
 			"instances": 1
 		},
 		{
@@ -1515,7 +1815,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1
 		},
 		{
@@ -1527,7 +1830,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1563,7 +1869,9 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.tsx",
 			"name": "RestaurantsSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1587,7 +1895,9 @@
 			"module": "src/pages/HomePage/components/CategoriesSection/CategoriesSection.tsx",
 			"name": "CategoriesSection",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1611,7 +1921,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["className"],
+			"props": [
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1635,7 +1947,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1659,7 +1973,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1671,7 +1987,9 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1695,7 +2013,11 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title", "topButtonLabel", "onTopButtonClick"],
+			"props": [
+				"title",
+				"topButtonLabel",
+				"onTopButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1707,7 +2029,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1719,7 +2044,10 @@
 			"module": "@droppy/design-system",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1731,7 +2059,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["round", "..."],
+			"props": [
+				"round",
+				"..."
+			],
 			"instances": 1
 		},
 		{
@@ -1743,7 +2074,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1755,7 +2088,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1767,7 +2103,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1779,7 +2117,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1791,7 +2133,12 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.container.tsx",
 			"name": "RestaurantsSectionComponent",
 			"weight": 1,
-			"props": ["title", "restaurants", "isLoading", "onRestaurantClick"],
+			"props": [
+				"title",
+				"restaurants",
+				"isLoading",
+				"onRestaurantClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1803,7 +2150,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1815,7 +2164,10 @@
 			"module": "@droppy/design-system",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1827,7 +2179,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1839,7 +2193,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1851,7 +2209,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1863,7 +2223,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1875,7 +2241,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1887,7 +2255,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1899,7 +2269,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1911,7 +2287,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1923,7 +2301,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1947,7 +2327,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1959,7 +2341,13 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItemModal/FoodItemModal.tsx",
 			"name": "FoodItemModal",
 			"weight": 1,
-			"props": ["item", "cartItems", "onClose", "onItemSave", "onItemRemove"],
+			"props": [
+				"item",
+				"cartItems",
+				"onClose",
+				"onItemSave",
+				"onItemRemove"
+			],
 			"instances": 1
 		},
 		{
@@ -1971,7 +2359,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["photoUrl", "onBackClick"],
+			"props": [
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1995,7 +2386,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2019,7 +2412,9 @@
 			"module": "@droppy/design-system",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -2031,7 +2426,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -2055,7 +2453,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2067,7 +2470,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2079,7 +2487,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2091,7 +2504,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2103,7 +2518,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["aria-label", "type", "fontWeight"],
+			"props": [
+				"aria-label",
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -2115,7 +2534,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2151,7 +2572,11 @@
 			"module": "@droppy/design-system",
 			"name": "Modal",
 			"weight": 1,
-			"props": ["isOpen", "onClose", "container"],
+			"props": [
+				"isOpen",
+				"onClose",
+				"container"
+			],
 			"instances": 1
 		},
 		{
@@ -2187,7 +2612,12 @@
 			"module": "@droppy/design-system",
 			"name": "QuantityStepper",
 			"weight": 1,
-			"props": ["value", "onChange", "min", "max"],
+			"props": [
+				"value",
+				"onChange",
+				"min",
+				"max"
+			],
 			"instances": 1
 		},
 		{
@@ -2199,7 +2629,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "onClick"],
+			"props": [
+				"aria-label",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2211,7 +2644,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2223,7 +2658,14 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItem/FoodItem.tsx",
 			"name": "FoodItem",
 			"weight": 1,
-			"props": ["key", "name", "price", "description", "quantity", "onClick"],
+			"props": [
+				"key",
+				"name",
+				"price",
+				"description",
+				"quantity",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2235,7 +2677,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2247,7 +2691,9 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2259,7 +2705,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2271,7 +2719,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2283,7 +2733,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -2307,7 +2759,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": ["sticky"],
+			"props": [
+				"sticky"
+			],
 			"instances": 1
 		},
 		{
@@ -2319,7 +2773,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "HeaderComponent",
 			"weight": 1,
-			"props": ["logoOnly"],
+			"props": [
+				"logoOnly"
+			],
 			"instances": 1
 		},
 		{
@@ -2331,8 +2787,12 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["header", "footer", "..."],
-			"instances": 1
+			"props": [
+				"header",
+				"footer",
+				"..."
+			],
+			"instances": 9
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2344,7 +2804,7 @@
 			"name": "Footer",
 			"weight": 1,
 			"props": [],
-			"instances": 1
+			"instances": 9
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
@@ -12,8 +12,7 @@
 			"module": "react-router-dom",
 			"name": "BrowserRouter",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]",
@@ -26,8 +25,7 @@
 			"weight": 1,
 			"props": [
 				"store"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/GlobalStyle[0]",
@@ -38,8 +36,7 @@
 			"module": "styled-components",
 			"name": "createGlobalStyle",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/AppRoutes[1]",
@@ -50,8 +47,7 @@
 			"module": "src/Routes.tsx",
 			"name": "AppRoutes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]",
@@ -62,8 +58,7 @@
 			"module": "react-router-dom",
 			"name": "Routes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[0]",
@@ -77,8 +72,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryListPage[0]",
@@ -89,8 +83,7 @@
 			"module": "src/pages/CategoryListPage/CategoryListPage.tsx",
 			"name": "CategoryListPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[1]",
@@ -104,8 +97,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryDetailPage[0]",
@@ -116,8 +108,7 @@
 			"module": "src/pages/CategoryDetailPage/CategoryDetailPage.tsx",
 			"name": "CategoryDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[2]",
@@ -131,8 +122,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/RestaurantDetailPage[0]",
@@ -143,8 +133,7 @@
 			"module": "src/pages/RestaurantDetailPage/RestaurantDetailPage.tsx",
 			"name": "RestaurantDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[3]",
@@ -158,8 +147,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CheckoutPage[0]",
@@ -170,8 +158,7 @@
 			"module": "src/pages/CheckoutPage/CheckoutPage.tsx",
 			"name": "CheckoutPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[4]",
@@ -185,8 +172,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/SuccessPage[0]",
@@ -197,8 +183,7 @@
 			"module": "src/pages/SuccessPage/SuccessPage.tsx",
 			"name": "SuccessPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[5]",
@@ -212,8 +197,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/HomePage[0]",
@@ -224,8 +208,7 @@
 			"module": "src/pages/HomePage/HomePage.tsx",
 			"name": "HomePage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AnimatedIllustration/span[0]/Lottie[0]",
@@ -241,8 +224,7 @@
 				"play",
 				"loop",
 				"animationData"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]",
@@ -255,8 +237,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]/Title[1]",
@@ -269,8 +250,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Squared/SquaredContainer[0]/FloatingTitle[1]/Body[0]",
@@ -284,8 +264,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Rounded[0]",
@@ -299,8 +278,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Squared[0]",
@@ -314,8 +292,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]",
@@ -326,8 +303,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/Logo[0]",
@@ -341,8 +317,7 @@
 			"props": [
 				"large",
 				"logoOnly"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[1]",
@@ -356,8 +331,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[2]",
@@ -371,8 +345,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Container[0]/FooterTop[0]/FooterCard[3]",
@@ -385,8 +358,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "FooterCard/DsFooterCard[0]",
@@ -401,8 +373,7 @@
 				"title",
 				"links",
 				"..."
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "render/RouterLink[0]",
@@ -415,8 +386,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -434,8 +404,7 @@
 				"icon",
 				"onClick",
 				"..."
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -449,8 +418,7 @@
 			"props": [
 				"to",
 				"aria-label"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]/Logo[0]",
@@ -461,8 +429,7 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/ThemeToggle[0]",
@@ -473,8 +440,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]",
@@ -488,8 +454,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]/Button[0]",
@@ -502,8 +467,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]",
@@ -517,8 +481,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]/Button[0]",
@@ -531,8 +494,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/Button[1]",
@@ -547,8 +509,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/CartLabel[0]/CartText[0]",
@@ -561,8 +522,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/CartLabel[0]/CartTotal[1]",
@@ -575,8 +535,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "HeaderComponent/ShoppingCartMenu[0]",
@@ -594,8 +553,7 @@
 				"cartItems",
 				"totalPrice",
 				"onItemChange"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Header/HeaderComponent[0]",
@@ -614,8 +572,7 @@
 				"toggleCartVisibility",
 				"totalPrice",
 				"saveItem"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Link/DsLink[0]",
@@ -629,8 +586,7 @@
 			"props": [
 				"render",
 				"..."
-			],
-			"instances": 14
+			]
 		},
 		{
 			"path": "Link/RouterLink[0]",
@@ -643,8 +599,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 14
+			]
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -658,8 +613,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 12
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]",
@@ -674,8 +628,7 @@
 				"data-testid",
 				"role",
 				"aria-label"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/Skeleton[0]",
@@ -689,8 +642,7 @@
 			"props": [
 				"height",
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]",
@@ -705,8 +657,7 @@
 				"aria-hidden",
 				"level",
 				"size"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]/Skeleton[0]",
@@ -719,8 +670,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[1]",
@@ -733,8 +683,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[1]/Skeleton[0]",
@@ -747,8 +696,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Description[2]",
@@ -759,8 +707,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Description[2]/Skeleton[0]",
@@ -771,8 +718,7 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[3]",
@@ -785,8 +731,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/ConstrainedCard[0]/StyledContent[1]/Body[3]/Skeleton[0]",
@@ -801,8 +746,7 @@
 				"width",
 				"height",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCard/RestaurantCardSkeleton[0]",
@@ -813,8 +757,7 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 1.5
+			"props": []
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]",
@@ -830,8 +773,7 @@
 				"className",
 				"data-testid",
 				"onClick"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Closed[0]/Body[0]",
@@ -844,8 +786,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/StyledHeading[0]",
@@ -859,8 +800,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/Review[1]",
@@ -873,8 +813,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/ConstrainedCard[0]/StyledContent[1]/Description[2]",
@@ -887,8 +826,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/StyledBadge[0]",
@@ -902,8 +840,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Body[0]",
@@ -916,8 +853,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Heading[0]",
@@ -930,8 +866,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Review[1]",
@@ -944,8 +879,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Body[2]",
@@ -958,8 +892,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/Badge[0]",
@@ -973,8 +906,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]",
@@ -985,8 +917,7 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/StyledHeading[0]",
@@ -1001,8 +932,7 @@
 				"level",
 				"size",
 				"$withMargin"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "OrderSummary/ShoppingCartItem[0]",
@@ -1016,8 +946,7 @@
 			"props": [
 				"key",
 				"item"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/Body[0]",
@@ -1028,8 +957,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 0.5,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/Body[0]",
@@ -1040,8 +968,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/TotalHeading[1]",
@@ -1055,8 +982,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Quantity[0]",
@@ -1069,8 +995,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Name[1]",
@@ -1083,8 +1008,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Price[2]",
@@ -1097,8 +1021,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[0]",
@@ -1111,8 +1034,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[1]",
@@ -1125,8 +1047,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Button[1]",
@@ -1141,8 +1062,7 @@
 				"disabled",
 				"large",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[0]",
@@ -1156,8 +1076,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[1]",
@@ -1168,8 +1087,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[2]",
@@ -1180,8 +1098,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/Select[1]",
@@ -1197,8 +1114,7 @@
 				"onChange",
 				"aria-label",
 				"options"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Sidebar[0]",
@@ -1215,8 +1131,7 @@
 				"isOpen",
 				"container",
 				"footer"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Footer[0]",
@@ -1230,8 +1145,7 @@
 			"props": [
 				"onClick",
 				"totalPrice"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/ShoppingCartMenuItem[0]",
@@ -1246,8 +1160,7 @@
 				"key",
 				"item",
 				"onChange"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "<module>/StrictMode[0]",
@@ -1258,8 +1171,7 @@
 			"module": "react",
 			"name": "StrictMode",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "<module>/StrictMode[0]/App[0]",
@@ -1270,8 +1182,7 @@
 			"module": "src/App.tsx",
 			"name": "App",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]",
@@ -1282,8 +1193,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/TopBanner[0]",
@@ -1298,8 +1208,7 @@
 				"title",
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/Container[1]",
@@ -1310,8 +1219,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/Container[1]/Breadcrumb[0]",
@@ -1324,8 +1232,7 @@
 			"weight": 1,
 			"props": [
 				"items"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "render/Link[0]",
@@ -1338,8 +1245,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/ErrorBlock[0]",
@@ -1356,8 +1262,7 @@
 				"illustration",
 				"buttonText",
 				"onButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCardSkeleton[0]",
@@ -1370,8 +1275,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCard[0]",
@@ -1386,8 +1290,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]",
@@ -1398,8 +1301,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/TopBanner[0]",
@@ -1413,8 +1315,7 @@
 			"props": [
 				"title",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]",
@@ -1425,8 +1326,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/StyledHeading[0]",
@@ -1439,8 +1339,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/StyledBody[1]",
@@ -1451,8 +1350,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/Container[1]/CategoryList[2]",
@@ -1465,8 +1363,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]",
@@ -1480,8 +1377,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]/Category[0]",
@@ -1495,8 +1391,7 @@
 			"props": [
 				"...",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]",
@@ -1509,8 +1404,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/TopContainer[0]/StyledHeading[0]",
@@ -1524,8 +1418,7 @@
 			"props": [
 				"level",
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomPull[1]/BottomContainer[0]",
@@ -1536,8 +1429,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomPull[1]/BottomContainer[0]/MultiStepForm[0]",
@@ -1548,8 +1440,7 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/MultiStepForm.tsx",
 			"name": "MultiStepForm",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomPull[1]/BottomContainer[0]/OrderDetailsContainer[1]/OrderSummary[0]",
@@ -1562,8 +1453,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[0]",
@@ -1581,8 +1471,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[1]",
@@ -1600,8 +1489,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[2]",
@@ -1620,8 +1508,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[3]",
@@ -1640,8 +1527,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/DisclaimerText[4]",
@@ -1655,8 +1541,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/div[5]/Button[0]",
@@ -1669,8 +1554,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[0]",
@@ -1688,8 +1572,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[1]",
@@ -1707,8 +1590,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[2]",
@@ -1726,8 +1608,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[0]",
@@ -1741,8 +1622,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[1]",
@@ -1755,8 +1635,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/ContactDetails[0]",
@@ -1771,8 +1650,7 @@
 				"formData",
 				"setFormData",
 				"onNext"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/DeliveryDetails[0]",
@@ -1787,8 +1665,7 @@
 				"formData",
 				"setFormData",
 				"onPrevious"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "MultiStepForm/FormContainer[0]/StepIndicator[0]",
@@ -1803,8 +1680,7 @@
 				"title",
 				"currentStep",
 				"amountOfSteps"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Heading[0]",
@@ -1818,8 +1694,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Body[1]",
@@ -1833,8 +1708,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]",
@@ -1845,8 +1719,7 @@
 			"module": "@droppy/design-system",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/Banner[0]",
@@ -1857,8 +1730,7 @@
 			"module": "src/pages/HomePage/components/Banner/Banner.tsx",
 			"name": "Banner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/RestaurantsSection[2]",
@@ -1871,8 +1743,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/AwardWinningSection[4]",
@@ -1883,8 +1754,7 @@
 			"module": "src/pages/HomePage/components/AwardWinningSection/AwardWinningSection.tsx",
 			"name": "AwardWinningSection",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/CategoriesSection[6]",
@@ -1897,8 +1767,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]",
@@ -1909,8 +1778,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[0]",
@@ -1923,8 +1791,7 @@
 			"weight": 1,
 			"props": [
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[1]",
@@ -1935,8 +1802,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]",
@@ -1949,8 +1815,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]/StyledButton[0]",
@@ -1961,8 +1826,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/StyledHeading[0]",
@@ -1975,8 +1839,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]",
@@ -1989,8 +1852,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]/Button[0]",
@@ -2001,8 +1863,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]",
@@ -2017,8 +1878,7 @@
 				"title",
 				"topButtonLabel",
 				"onTopButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]/Carousel[0]",
@@ -2032,8 +1892,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]",
@@ -2047,8 +1906,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]/Category[0]",
@@ -2062,8 +1920,7 @@
 			"props": [
 				"round",
 				"..."
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]",
@@ -2076,8 +1933,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]/Carousel[0]",
@@ -2091,8 +1947,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCardSkeleton[0]",
@@ -2105,8 +1960,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCard[0]",
@@ -2121,8 +1975,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantsSectionComponent[0]",
@@ -2138,8 +1991,7 @@
 				"restaurants",
 				"isLoading",
 				"onRestaurantClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]",
@@ -2152,8 +2004,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]/Carousel[0]",
@@ -2167,8 +2018,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCardSkeleton[0]",
@@ -2181,8 +2031,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCard[0]",
@@ -2197,8 +2046,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]",
@@ -2211,8 +2059,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]",
@@ -2229,8 +2076,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]",
@@ -2243,8 +2089,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#2",
@@ -2257,8 +2102,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]#2",
@@ -2275,8 +2119,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]#2",
@@ -2289,8 +2132,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#3",
@@ -2303,8 +2145,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/SpinnerContainer[0]/Spinner[0]",
@@ -2315,8 +2156,7 @@
 			"module": "@droppy/design-system",
 			"name": "Spinner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#4",
@@ -2329,8 +2169,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/FoodItemModal[0]",
@@ -2347,8 +2186,7 @@
 				"onClose",
 				"onItemSave",
 				"onItemRemove"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/TopBanner[1]",
@@ -2362,8 +2200,7 @@
 			"props": [
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]",
@@ -2374,8 +2211,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/Heading[0]",
@@ -2388,8 +2224,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/Body[1]",
@@ -2400,8 +2235,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/Container[0]/StyledReview[2]",
@@ -2414,8 +2248,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/StyledBadge[0]",
@@ -2429,8 +2262,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/MenuSection[3]/Container[0]",
@@ -2441,8 +2273,7 @@
 			"module": "@droppy/design-system",
 			"name": "Container",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]",
@@ -2458,8 +2289,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#2",
@@ -2475,8 +2305,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#3",
@@ -2492,8 +2321,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]",
@@ -2506,8 +2334,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Quantity[0]",
@@ -2522,8 +2349,7 @@
 				"aria-label",
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Heading[0]",
@@ -2536,8 +2362,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Description[1]",
@@ -2548,8 +2373,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Price[2]",
@@ -2560,8 +2384,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/Modal[0]",
@@ -2576,8 +2399,7 @@
 				"isOpen",
 				"onClose",
 				"container"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/Heading[0]",
@@ -2588,8 +2410,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/StyledBody[1]",
@@ -2600,8 +2421,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/QuantityStepper[0]",
@@ -2617,8 +2437,7 @@
 				"onChange",
 				"min",
 				"max"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/StyledButton[1]",
@@ -2632,8 +2451,7 @@
 			"props": [
 				"aria-label",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodSection/div[0]/StyledHeading[0]",
@@ -2646,8 +2464,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodSection/FoodItem[0]",
@@ -2665,8 +2482,7 @@
 				"description",
 				"quantity",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]",
@@ -2679,8 +2495,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/TopBanner[0]",
@@ -2693,8 +2508,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/Body[0]",
@@ -2707,8 +2521,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/StyledHeading[1]",
@@ -2721,8 +2534,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/OrderSummary[2]",
@@ -2735,8 +2547,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "default/Header[0]",
@@ -2747,8 +2558,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "headers/Header[0]",
@@ -2761,8 +2571,7 @@
 			"weight": 1,
 			"props": [
 				"sticky"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "basic/HeaderComponent[0]",
@@ -2775,8 +2584,7 @@
 			"weight": 1,
 			"props": [
 				"logoOnly"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageTemplate/DsPageTemplate[0]",
@@ -2791,8 +2599,7 @@
 				"header",
 				"footer",
 				"..."
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2803,8 +2610,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
@@ -12,8 +12,7 @@
 			"module": "react-router-dom",
 			"name": "BrowserRouter",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]",
@@ -26,8 +25,7 @@
 			"weight": 1,
 			"props": [
 				"store"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]",
@@ -40,8 +38,7 @@
 			"weight": 1,
 			"props": [
 				"theme"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/GlobalStyle[0]",
@@ -52,8 +49,7 @@
 			"module": "styled-components",
 			"name": "createGlobalStyle",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/AppRoutes[1]",
@@ -64,8 +60,7 @@
 			"module": "src/Routes.tsx",
 			"name": "AppRoutes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]",
@@ -76,8 +71,7 @@
 			"module": "react-router-dom",
 			"name": "Routes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[0]",
@@ -91,8 +85,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryListPage[0]",
@@ -103,8 +96,7 @@
 			"module": "src/pages/CategoryListPage/CategoryListPage.tsx",
 			"name": "CategoryListPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[1]",
@@ -118,8 +110,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryDetailPage[0]",
@@ -130,8 +121,7 @@
 			"module": "src/pages/CategoryDetailPage/CategoryDetailPage.tsx",
 			"name": "CategoryDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[2]",
@@ -145,8 +135,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/RestaurantDetailPage[0]",
@@ -157,8 +146,7 @@
 			"module": "src/pages/RestaurantDetailPage/RestaurantDetailPage.tsx",
 			"name": "RestaurantDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[3]",
@@ -172,8 +160,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CheckoutPage[0]",
@@ -184,8 +171,7 @@
 			"module": "src/pages/CheckoutPage/CheckoutPage.tsx",
 			"name": "CheckoutPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[4]",
@@ -199,8 +185,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/SuccessPage[0]",
@@ -211,8 +196,7 @@
 			"module": "src/pages/SuccessPage/SuccessPage.tsx",
 			"name": "SuccessPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[5]",
@@ -226,8 +210,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/HomePage[0]",
@@ -238,8 +221,7 @@
 			"module": "src/pages/HomePage/HomePage.tsx",
 			"name": "HomePage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AnimatedIllustration/span[0]/Lottie[0]",
@@ -255,8 +237,7 @@
 				"play",
 				"loop",
 				"animationData"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Carousel/PreviousButton[0]",
@@ -271,8 +252,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Carousel/NextButton[0]",
@@ -287,8 +267,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]",
@@ -301,8 +280,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]/Title[1]/Body[0]",
@@ -315,8 +293,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Squared/SquaredContainer[0]/FloatingTitle[1]/Body[0]",
@@ -330,8 +307,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Rounded[0]",
@@ -345,8 +321,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Squared[0]",
@@ -360,8 +335,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/Logo[0]",
@@ -375,8 +349,7 @@
 			"props": [
 				"large",
 				"logoOnly"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[1]",
@@ -390,8 +363,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[2]",
@@ -405,8 +377,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[3]",
@@ -419,8 +390,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "FooterCard/FooterCardContainer[0]/Heading[0]",
@@ -433,8 +403,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 54
+			]
 		},
 		{
 			"path": "FooterCard/li[0]/Body[0]",
@@ -445,8 +414,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 54
+			"props": []
 		},
 		{
 			"path": "FooterCard/Link[0]",
@@ -459,8 +427,7 @@
 			"weight": 0.5,
 			"props": [
 				"to"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -477,8 +444,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -492,8 +458,7 @@
 			"props": [
 				"to",
 				"aria-label"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]/Logo[0]",
@@ -504,8 +469,7 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/ThemeToggle[0]",
@@ -516,8 +480,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "ThemeToggle",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]",
@@ -531,8 +494,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]/Button[0]",
@@ -545,8 +507,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]",
@@ -560,8 +521,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]/Button[0]",
@@ -574,8 +534,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/Button[1]",
@@ -590,8 +549,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartText[0]",
@@ -604,8 +562,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartTotal[0]",
@@ -618,8 +575,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/ShoppingCartMenu[0]",
@@ -637,8 +593,7 @@
 				"cartItems",
 				"totalPrice",
 				"onItemChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Header/HeaderComponent[0]",
@@ -657,8 +612,7 @@
 				"toggleCartVisibility",
 				"totalPrice",
 				"saveItem"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -672,8 +626,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 45
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]",
@@ -686,8 +639,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/Skeleton[0]",
@@ -701,8 +653,7 @@
 			"props": [
 				"height",
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/StyledHeading[0]",
@@ -716,8 +667,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/StyledHeading[0]/Skeleton[0]",
@@ -730,8 +680,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[1]",
@@ -744,8 +693,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[1]/Skeleton[0]",
@@ -758,8 +706,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Description[2]",
@@ -770,8 +717,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Description[2]/Skeleton[0]",
@@ -782,8 +728,7 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[3]",
@@ -796,8 +741,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[3]/Skeleton[0]",
@@ -812,8 +756,7 @@
 				"width",
 				"height",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCard/RestaurantCardSkeleton[0]",
@@ -824,8 +767,7 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 1.5
+			"props": []
 		},
 		{
 			"path": "RestaurantCard/Card[0]",
@@ -841,8 +783,7 @@
 				"className",
 				"data-testid",
 				"onClick"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/NewBadge[0]",
@@ -856,8 +797,7 @@
 			"props": [
 				"text",
 				"variant"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Closed[0]/Body[0]",
@@ -870,8 +810,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/StyledHeading[0]",
@@ -885,8 +824,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/Review[1]",
@@ -899,8 +837,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/Description[2]",
@@ -913,8 +850,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/StyledBadge[0]",
@@ -928,8 +864,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Body[0]",
@@ -942,8 +877,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Heading[0]",
@@ -956,8 +890,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Review[1]",
@@ -970,8 +903,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Body[2]",
@@ -984,8 +916,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/Badge[0]",
@@ -999,8 +930,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Review/Wrapper[0]/StyledBody[0]",
@@ -1015,8 +945,7 @@
 				"size",
 				"type",
 				"className"
-			],
-			"instances": 3.5
+			]
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]",
@@ -1027,8 +956,7 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/StyledHeading[0]",
@@ -1043,8 +971,7 @@
 				"level",
 				"size",
 				"$withMargin"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "OrderSummary/ShoppingCartItem[0]",
@@ -1058,8 +985,7 @@
 			"props": [
 				"key",
 				"item"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/Body[0]",
@@ -1070,8 +996,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 0.5,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/Body[0]",
@@ -1082,8 +1007,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/TotalHeading[1]",
@@ -1097,8 +1021,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Quantity[0]",
@@ -1111,8 +1034,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Name[1]",
@@ -1125,8 +1047,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Price[2]",
@@ -1139,8 +1060,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[0]",
@@ -1153,8 +1073,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[1]",
@@ -1167,8 +1086,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Button[1]",
@@ -1183,8 +1101,7 @@
 				"disabled",
 				"large",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[0]",
@@ -1198,8 +1115,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[1]",
@@ -1210,8 +1126,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[2]",
@@ -1222,8 +1137,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/Select[1]",
@@ -1239,8 +1153,7 @@
 				"onChange",
 				"aria-label",
 				"options"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Sidebar[0]",
@@ -1257,8 +1170,7 @@
 				"isOpen",
 				"container",
 				"footer"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Footer[0]",
@@ -1272,8 +1184,7 @@
 			"props": [
 				"onClick",
 				"totalPrice"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/ShoppingCartMenuItem[0]",
@@ -1288,8 +1199,7 @@
 				"key",
 				"item",
 				"onChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Input/Wrapper[0]/DsInput[0]",
@@ -1302,8 +1212,7 @@
 			"weight": 1,
 			"props": [
 				"..."
-			],
-			"instances": 7
+			]
 		},
 		{
 			"path": "<module>/StrictMode[0]",
@@ -1314,8 +1223,7 @@
 			"module": "react",
 			"name": "StrictMode",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "<module>/StrictMode[0]/App[0]",
@@ -1326,8 +1234,7 @@
 			"module": "src/App.tsx",
 			"name": "App",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]",
@@ -1338,8 +1245,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/TopBanner[0]",
@@ -1354,8 +1260,7 @@
 				"title",
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/div[1]/Breadcrumb[0]",
@@ -1368,8 +1273,7 @@
 			"weight": 1,
 			"props": [
 				"items"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "render/Link[0]",
@@ -1382,8 +1286,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/ErrorBlock[0]",
@@ -1400,8 +1303,7 @@
 				"illustration",
 				"buttonText",
 				"onButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCardSkeleton[0]",
@@ -1414,8 +1316,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCard[0]",
@@ -1430,8 +1331,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]",
@@ -1442,8 +1342,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/TopBanner[0]",
@@ -1457,8 +1356,7 @@
 			"props": [
 				"title",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledHeading[0]",
@@ -1471,8 +1369,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledBody[1]",
@@ -1483,8 +1380,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/CategoryList[2]",
@@ -1497,8 +1393,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]",
@@ -1512,8 +1407,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]/Category[0]",
@@ -1527,8 +1421,7 @@
 			"props": [
 				"...",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]",
@@ -1541,8 +1434,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/TopContainer[0]/StyledHeading[0]",
@@ -1556,8 +1448,7 @@
 			"props": [
 				"level",
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/MultiStepForm[0]",
@@ -1568,8 +1459,7 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/MultiStepForm.tsx",
 			"name": "MultiStepForm",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/OrderDetailsContainer[1]/OrderSummary[0]",
@@ -1582,8 +1472,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[0]",
@@ -1601,8 +1490,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[1]",
@@ -1620,8 +1508,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[2]",
@@ -1640,8 +1527,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[3]",
@@ -1660,8 +1546,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/DisclaimerText[4]",
@@ -1675,8 +1560,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/div[5]/Button[0]",
@@ -1689,8 +1573,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[0]",
@@ -1708,8 +1591,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[1]",
@@ -1727,8 +1609,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[2]",
@@ -1746,8 +1627,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[0]",
@@ -1761,8 +1641,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[1]",
@@ -1775,8 +1654,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/ContactDetails[0]",
@@ -1791,8 +1669,7 @@
 				"formData",
 				"setFormData",
 				"onNext"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/DeliveryDetails[0]",
@@ -1807,8 +1684,7 @@
 				"formData",
 				"setFormData",
 				"onPrevious"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "MultiStepForm/FormContainer[0]/StepIndicator[0]",
@@ -1823,8 +1699,7 @@
 				"title",
 				"currentStep",
 				"amountOfSteps"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Heading[0]",
@@ -1838,8 +1713,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Body[1]",
@@ -1853,8 +1727,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]",
@@ -1865,8 +1738,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/Banner[0]",
@@ -1877,8 +1749,7 @@
 			"module": "src/pages/HomePage/components/Banner/Banner.tsx",
 			"name": "Banner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/RestaurantsSection[2]",
@@ -1891,8 +1762,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/AwardWinningSection[4]",
@@ -1903,8 +1773,7 @@
 			"module": "src/pages/HomePage/components/AwardWinningSection/AwardWinningSection.tsx",
 			"name": "AwardWinningSection",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/CategoriesSection[6]",
@@ -1917,8 +1786,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[0]",
@@ -1931,8 +1799,7 @@
 			"weight": 1,
 			"props": [
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[1]",
@@ -1943,8 +1810,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]",
@@ -1957,8 +1823,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]/StyledButton[0]",
@@ -1969,8 +1834,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/StyledHeading[0]",
@@ -1983,8 +1847,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]",
@@ -1997,8 +1860,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]/Button[0]",
@@ -2009,8 +1871,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]",
@@ -2025,8 +1886,7 @@
 				"title",
 				"topButtonLabel",
 				"onTopButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]/Carousel[0]",
@@ -2040,8 +1900,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]",
@@ -2055,8 +1914,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]/Category[0]",
@@ -2070,8 +1928,7 @@
 			"props": [
 				"round",
 				"..."
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]",
@@ -2084,8 +1941,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]/Carousel[0]",
@@ -2099,8 +1955,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCardSkeleton[0]",
@@ -2113,8 +1968,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCard[0]",
@@ -2129,8 +1983,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantsSectionComponent[0]",
@@ -2146,8 +1999,7 @@
 				"restaurants",
 				"isLoading",
 				"onRestaurantClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]",
@@ -2160,8 +2012,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]/Carousel[0]",
@@ -2175,8 +2026,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCardSkeleton[0]",
@@ -2189,8 +2039,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCard[0]",
@@ -2205,8 +2054,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]",
@@ -2219,8 +2067,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]",
@@ -2237,8 +2084,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]",
@@ -2251,8 +2097,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#2",
@@ -2265,8 +2110,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]#2",
@@ -2283,8 +2127,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]#2",
@@ -2297,8 +2140,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#3",
@@ -2311,8 +2153,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/Spinner[0]",
@@ -2323,8 +2164,7 @@
 			"module": "src/components/Spinner/Spinner.tsx",
 			"name": "Spinner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#4",
@@ -2337,8 +2177,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/FoodItemModal[0]",
@@ -2355,8 +2194,7 @@
 				"onClose",
 				"onItemSave",
 				"onItemRemove"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/TopBanner[1]",
@@ -2370,8 +2208,7 @@
 			"props": [
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Heading[0]",
@@ -2384,8 +2221,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Body[1]",
@@ -2396,8 +2232,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Review[2]",
@@ -2410,8 +2245,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/StyledBadge[0]",
@@ -2425,8 +2259,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]",
@@ -2442,8 +2275,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#2",
@@ -2459,8 +2291,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#3",
@@ -2476,8 +2307,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]",
@@ -2490,8 +2320,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Quantity[0]",
@@ -2506,8 +2335,7 @@
 				"aria-label",
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Heading[0]",
@@ -2520,8 +2348,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Description[1]",
@@ -2532,8 +2359,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Price[2]",
@@ -2544,8 +2370,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/Modal[0]",
@@ -2560,8 +2385,7 @@
 				"isOpen",
 				"onClose",
 				"container"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/Heading[0]",
@@ -2572,8 +2396,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/StyledBody[1]",
@@ -2584,8 +2407,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/QuantityStepper[0]",
@@ -2601,8 +2423,7 @@
 				"onChange",
 				"min",
 				"max"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/StyledButton[1]",
@@ -2616,8 +2437,7 @@
 			"props": [
 				"aria-label",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodSection/div[0]/StyledHeading[0]",
@@ -2630,8 +2450,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodSection/FoodItem[0]",
@@ -2649,8 +2468,7 @@
 				"description",
 				"quantity",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]",
@@ -2663,8 +2481,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/TopBanner[0]",
@@ -2677,8 +2494,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/Body[0]",
@@ -2691,8 +2507,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/StyledHeading[1]",
@@ -2705,8 +2520,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/OrderSummary[2]",
@@ -2719,8 +2533,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]",
@@ -2733,8 +2546,7 @@
 			"weight": 1,
 			"props": [
 				"sticky"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2745,8 +2557,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/HeaderComponent[0]",
@@ -2759,8 +2570,7 @@
 			"weight": 1,
 			"props": [
 				"logoOnly"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]#2",
@@ -2771,8 +2581,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/Footer[0]#2",
@@ -2783,8 +2592,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
@@ -24,7 +24,9 @@
 			"module": "react-redux",
 			"name": "Provider",
 			"weight": 1,
-			"props": ["store"],
+			"props": [
+				"store"
+			],
 			"instances": 1
 		},
 		{
@@ -36,7 +38,9 @@
 			"module": "styled-components",
 			"name": "ThemeProvider",
 			"weight": 1,
-			"props": ["theme"],
+			"props": [
+				"theme"
+			],
 			"instances": 1
 		},
 		{
@@ -84,7 +88,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -108,7 +115,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -132,7 +142,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -156,7 +169,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -180,7 +196,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -204,7 +223,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -228,7 +250,12 @@
 			"module": "react-lottie-player",
 			"name": "default",
 			"weight": 1,
-			"props": ["style", "play", "loop", "animationData"],
+			"props": [
+				"style",
+				"play",
+				"loop",
+				"animationData"
+			],
 			"instances": 2
 		},
 		{
@@ -240,7 +267,11 @@
 			"module": "@droppy/design-system",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -252,7 +283,11 @@
 			"module": "@droppy/design-system",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -264,7 +299,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 1
 		},
 		{
@@ -276,7 +313,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -288,7 +327,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -300,7 +342,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Rounded",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -312,7 +357,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Squared",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -324,7 +372,10 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": ["large", "logoOnly"],
+			"props": [
+				"large",
+				"logoOnly"
+			],
 			"instances": 18
 		},
 		{
@@ -336,7 +387,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -348,7 +402,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -360,7 +417,9 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 18
 		},
 		{
@@ -372,7 +431,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 54
 		},
 		{
@@ -396,7 +457,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 0.5,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 27
 		},
 		{
@@ -408,7 +471,13 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["round", "clear", "aria-label", "icon", "onClick"],
+			"props": [
+				"round",
+				"clear",
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -420,7 +489,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "aria-label"],
+			"props": [
+				"to",
+				"aria-label"
+			],
 			"instances": 27
 		},
 		{
@@ -456,7 +528,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -468,7 +543,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -480,7 +557,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -492,7 +572,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -504,7 +586,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "icon", "onClick"],
+			"props": [
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -516,7 +602,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -528,7 +616,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -579,7 +669,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 45
 		},
 		{
@@ -591,7 +684,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 3
 		},
 		{
@@ -603,7 +698,10 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["height", "width"],
+			"props": [
+				"height",
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -615,7 +713,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 3
 		},
 		{
@@ -627,7 +728,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -639,7 +742,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -651,7 +756,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -687,7 +794,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -699,7 +808,11 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width", "height", "style"],
+			"props": [
+				"width",
+				"height",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -723,7 +836,12 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["interactive", "className", "data-testid", "onClick"],
+			"props": [
+				"interactive",
+				"className",
+				"data-testid",
+				"onClick"
+			],
 			"instances": 1.5
 		},
 		{
@@ -735,7 +853,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["text", "variant"],
+			"props": [
+				"text",
+				"variant"
+			],
 			"instances": 1.5
 		},
 		{
@@ -747,7 +868,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1.5
 		},
 		{
@@ -759,7 +882,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1.5
 		},
 		{
@@ -771,7 +897,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1.5
 		},
 		{
@@ -783,7 +911,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1.5
 		},
 		{
@@ -795,7 +925,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1.5
 		},
 		{
@@ -807,7 +940,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -819,7 +954,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -831,7 +968,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -843,7 +982,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -855,7 +996,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -867,7 +1011,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type", "className"],
+			"props": [
+				"size",
+				"type",
+				"className"
+			],
 			"instances": 3.5
 		},
 		{
@@ -891,7 +1039,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size", "$withMargin"],
+			"props": [
+				"level",
+				"size",
+				"$withMargin"
+			],
 			"instances": 2
 		},
 		{
@@ -903,7 +1055,10 @@
 			"module": "src/components/ShoppingCart/ShoppingCartItem/ShoppingCartItem.tsx",
 			"name": "ShoppingCartItem",
 			"weight": 0.5,
-			"props": ["key", "item"],
+			"props": [
+				"key",
+				"item"
+			],
 			"instances": 1
 		},
 		{
@@ -939,7 +1094,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 2
 		},
 		{
@@ -951,7 +1109,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -963,7 +1123,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -975,7 +1137,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -987,7 +1151,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -999,7 +1165,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -1011,7 +1179,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["disabled", "large", "onClick"],
+			"props": [
+				"disabled",
+				"large",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -1023,7 +1195,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 27
 		},
 		{
@@ -1059,7 +1234,12 @@
 			"module": "@droppy/design-system",
 			"name": "Select",
 			"weight": 1,
-			"props": ["value", "onChange", "aria-label", "options"],
+			"props": [
+				"value",
+				"onChange",
+				"aria-label",
+				"options"
+			],
 			"instances": 27
 		},
 		{
@@ -1071,7 +1251,13 @@
 			"module": "@droppy/design-system",
 			"name": "Sidebar",
 			"weight": 1,
-			"props": ["title", "onClose", "isOpen", "container", "footer"],
+			"props": [
+				"title",
+				"onClose",
+				"isOpen",
+				"container",
+				"footer"
+			],
 			"instances": 27
 		},
 		{
@@ -1083,7 +1269,10 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": ["onClick", "totalPrice"],
+			"props": [
+				"onClick",
+				"totalPrice"
+			],
 			"instances": 27
 		},
 		{
@@ -1095,7 +1284,11 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "ShoppingCartMenuItem",
 			"weight": 1,
-			"props": ["key", "item", "onChange"],
+			"props": [
+				"key",
+				"item",
+				"onChange"
+			],
 			"instances": 27
 		},
 		{
@@ -1107,7 +1300,9 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["..."],
+			"props": [
+				"..."
+			],
 			"instances": 7
 		},
 		{
@@ -1155,7 +1350,11 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "photoUrl", "onBackClick"],
+			"props": [
+				"title",
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1167,7 +1366,9 @@
 			"module": "@droppy/design-system",
 			"name": "Breadcrumb",
 			"weight": 1,
-			"props": ["items"],
+			"props": [
+				"items"
+			],
 			"instances": 1
 		},
 		{
@@ -1179,7 +1380,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1191,7 +1394,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["body", "title", "illustration", "buttonText", "onButtonClick"],
+			"props": [
+				"body",
+				"title",
+				"illustration",
+				"buttonText",
+				"onButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1203,7 +1412,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1215,7 +1426,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1239,7 +1454,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "onBackClick"],
+			"props": [
+				"title",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1251,7 +1469,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1275,7 +1495,9 @@
 			"module": "src/pages/CategoryListPage/components/CategoryList/CategoryList.tsx",
 			"name": "CategoryList",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1287,7 +1509,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1299,7 +1524,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["...", "title"],
+			"props": [
+				"...",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1311,7 +1539,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1323,7 +1553,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "className"],
+			"props": [
+				"level",
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1347,7 +1580,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -1359,7 +1594,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1371,7 +1613,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1383,7 +1632,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "type", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"type",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1395,7 +1652,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "type", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"type",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1407,7 +1672,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1419,7 +1687,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1431,7 +1701,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1443,7 +1720,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1455,7 +1739,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1467,7 +1758,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1479,7 +1773,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1491,7 +1787,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/ContactDetails.tsx",
 			"name": "ContactDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onNext"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onNext"
+			],
 			"instances": 1
 		},
 		{
@@ -1503,7 +1803,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/DeliveryDetails.tsx",
 			"name": "DeliveryDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onPrevious"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onPrevious"
+			],
 			"instances": 1
 		},
 		{
@@ -1515,7 +1819,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/StepIndicator.tsx",
 			"name": "StepIndicator",
 			"weight": 1,
-			"props": ["title", "currentStep", "amountOfSteps"],
+			"props": [
+				"title",
+				"currentStep",
+				"amountOfSteps"
+			],
 			"instances": 1
 		},
 		{
@@ -1527,7 +1835,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1
 		},
 		{
@@ -1539,7 +1850,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1575,7 +1889,9 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.tsx",
 			"name": "RestaurantsSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1599,7 +1915,9 @@
 			"module": "src/pages/HomePage/components/CategoriesSection/CategoriesSection.tsx",
 			"name": "CategoriesSection",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1611,7 +1929,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["className"],
+			"props": [
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1635,7 +1955,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1659,7 +1981,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1671,7 +1995,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1695,7 +2021,11 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title", "topButtonLabel", "onTopButtonClick"],
+			"props": [
+				"title",
+				"topButtonLabel",
+				"onTopButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1707,7 +2037,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1719,7 +2052,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1731,7 +2067,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["round", "..."],
+			"props": [
+				"round",
+				"..."
+			],
 			"instances": 1
 		},
 		{
@@ -1743,7 +2082,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1755,7 +2096,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1767,7 +2111,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1779,7 +2125,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1791,7 +2141,12 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.container.tsx",
 			"name": "RestaurantsSectionComponent",
 			"weight": 1,
-			"props": ["title", "restaurants", "isLoading", "onRestaurantClick"],
+			"props": [
+				"title",
+				"restaurants",
+				"isLoading",
+				"onRestaurantClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1803,7 +2158,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1815,7 +2172,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1827,7 +2187,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1839,7 +2201,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1851,7 +2217,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1863,7 +2231,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1875,7 +2249,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1887,7 +2263,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1899,7 +2277,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1911,7 +2295,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1923,7 +2309,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1947,7 +2335,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1959,7 +2349,13 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItemModal/FoodItemModal.tsx",
 			"name": "FoodItemModal",
 			"weight": 1,
-			"props": ["item", "cartItems", "onClose", "onItemSave", "onItemRemove"],
+			"props": [
+				"item",
+				"cartItems",
+				"onClose",
+				"onItemSave",
+				"onItemRemove"
+			],
 			"instances": 1
 		},
 		{
@@ -1971,7 +2367,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["photoUrl", "onBackClick"],
+			"props": [
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1983,7 +2382,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2007,7 +2408,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -2019,7 +2422,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -2031,7 +2437,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2043,7 +2454,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2055,7 +2471,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2067,7 +2488,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2079,7 +2502,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["aria-label", "type", "fontWeight"],
+			"props": [
+				"aria-label",
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -2091,7 +2518,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2127,7 +2556,11 @@
 			"module": "@droppy/design-system",
 			"name": "Modal",
 			"weight": 1,
-			"props": ["isOpen", "onClose", "container"],
+			"props": [
+				"isOpen",
+				"onClose",
+				"container"
+			],
 			"instances": 1
 		},
 		{
@@ -2163,7 +2596,12 @@
 			"module": "@droppy/design-system",
 			"name": "QuantityStepper",
 			"weight": 1,
-			"props": ["value", "onChange", "min", "max"],
+			"props": [
+				"value",
+				"onChange",
+				"min",
+				"max"
+			],
 			"instances": 1
 		},
 		{
@@ -2175,7 +2613,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "onClick"],
+			"props": [
+				"aria-label",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2187,7 +2628,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2199,7 +2642,14 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItem/FoodItem.tsx",
 			"name": "FoodItem",
 			"weight": 1,
-			"props": ["key", "name", "price", "description", "quantity", "onClick"],
+			"props": [
+				"key",
+				"name",
+				"price",
+				"description",
+				"quantity",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2211,7 +2661,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2223,7 +2675,9 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2235,7 +2689,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2247,7 +2703,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2259,7 +2717,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -2271,7 +2731,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": ["sticky"],
+			"props": [
+				"sticky"
+			],
 			"instances": 9
 		},
 		{
@@ -2295,7 +2757,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "HeaderComponent",
 			"weight": 1,
-			"props": ["logoOnly"],
+			"props": [
+				"logoOnly"
+			],
 			"instances": 9
 		},
 		{

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
@@ -12,8 +12,7 @@
 			"module": "react-router-dom",
 			"name": "BrowserRouter",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]",
@@ -26,8 +25,7 @@
 			"weight": 1,
 			"props": [
 				"store"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]",
@@ -40,8 +38,7 @@
 			"weight": 1,
 			"props": [
 				"theme"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/GlobalStyle[0]",
@@ -52,8 +49,7 @@
 			"module": "styled-components",
 			"name": "createGlobalStyle",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "App/Router[0]/StoreProvider[0]/ThemeProvider[0]/AppRoutes[1]",
@@ -64,8 +60,7 @@
 			"module": "src/Routes.tsx",
 			"name": "AppRoutes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]",
@@ -76,8 +71,7 @@
 			"module": "react-router-dom",
 			"name": "Routes",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[0]",
@@ -91,8 +85,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryListPage[0]",
@@ -103,8 +96,7 @@
 			"module": "src/pages/CategoryListPage/CategoryListPage.tsx",
 			"name": "CategoryListPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[1]",
@@ -118,8 +110,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CategoryDetailPage[0]",
@@ -130,8 +121,7 @@
 			"module": "src/pages/CategoryDetailPage/CategoryDetailPage.tsx",
 			"name": "CategoryDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[2]",
@@ -145,8 +135,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/RestaurantDetailPage[0]",
@@ -157,8 +146,7 @@
 			"module": "src/pages/RestaurantDetailPage/RestaurantDetailPage.tsx",
 			"name": "RestaurantDetailPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[3]",
@@ -172,8 +160,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/CheckoutPage[0]",
@@ -184,8 +171,7 @@
 			"module": "src/pages/CheckoutPage/CheckoutPage.tsx",
 			"name": "CheckoutPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[4]",
@@ -199,8 +185,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/SuccessPage[0]",
@@ -211,8 +196,7 @@
 			"module": "src/pages/SuccessPage/SuccessPage.tsx",
 			"name": "SuccessPage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AppRoutes/Routes[0]/Route[5]",
@@ -226,8 +210,7 @@
 			"props": [
 				"path",
 				"element"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AppRoutes/HomePage[0]",
@@ -238,8 +221,7 @@
 			"module": "src/pages/HomePage/HomePage.tsx",
 			"name": "HomePage",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AnimatedIllustration/span[0]/Lottie[0]",
@@ -255,8 +237,7 @@
 				"play",
 				"loop",
 				"animationData"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "Carousel/PreviousButton[0]",
@@ -271,8 +252,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Carousel/NextButton[0]",
@@ -287,8 +267,7 @@
 				"name",
 				"aria-label",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]",
@@ -301,8 +280,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Rounded/RoundCard[0]/Title[1]/Body[0]",
@@ -315,8 +293,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Squared/SquaredContainer[0]/FloatingTitle[1]/Body[0]",
@@ -330,8 +307,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Rounded[0]",
@@ -345,8 +321,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Category/Squared[0]",
@@ -360,8 +335,7 @@
 			"props": [
 				"photoUrl",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/Logo[0]",
@@ -375,8 +349,7 @@
 			"props": [
 				"large",
 				"logoOnly"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[1]",
@@ -390,8 +363,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[2]",
@@ -405,8 +377,7 @@
 			"props": [
 				"title",
 				"links"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/div[0]/FooterTop[0]/FooterCard[3]",
@@ -419,8 +390,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "FooterCard/FooterCardContainer[0]/Heading[0]",
@@ -433,8 +403,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 54
+			]
 		},
 		{
 			"path": "FooterCard/li[0]/Body[0]",
@@ -445,8 +414,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 54
+			"props": []
 		},
 		{
 			"path": "FooterCard/Link[0]",
@@ -459,8 +427,7 @@
 			"weight": 0.5,
 			"props": [
 				"to"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ThemeToggle/Button[0]",
@@ -477,8 +444,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]",
@@ -492,8 +458,7 @@
 			"props": [
 				"to",
 				"aria-label"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/HeaderContainer[0]/LogoContainer[0]/Logo[0]",
@@ -504,8 +469,7 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/ThemeToggle[0]",
@@ -516,8 +480,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "ThemeToggle",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]",
@@ -531,8 +494,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[1]/Button[0]",
@@ -545,8 +507,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]",
@@ -560,8 +521,7 @@
 			"props": [
 				"to",
 				"tabIndex"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/span[0]/Link[2]/Button[0]",
@@ -574,8 +534,7 @@
 			"weight": 1,
 			"props": [
 				"clear"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/OptionsContainer[0]/Button[1]",
@@ -590,8 +549,7 @@
 				"aria-label",
 				"icon",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartText[0]",
@@ -604,8 +562,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/CartTotal[0]",
@@ -618,8 +575,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "HeaderComponent/ShoppingCartMenu[0]",
@@ -637,8 +593,7 @@
 				"cartItems",
 				"totalPrice",
 				"onItemChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Header/HeaderComponent[0]",
@@ -657,8 +612,7 @@
 				"toggleCartVisibility",
 				"totalPrice",
 				"saveItem"
-			],
-			"instances": 18
+			]
 		},
 		{
 			"path": "Logo/Heading[0]",
@@ -672,8 +626,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 45
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]",
@@ -686,8 +639,7 @@
 			"weight": 1,
 			"props": [
 				"data-testid"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/Skeleton[0]",
@@ -701,8 +653,7 @@
 			"props": [
 				"height",
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/StyledHeading[0]",
@@ -716,8 +667,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/StyledHeading[0]/Skeleton[0]",
@@ -730,8 +680,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[1]",
@@ -744,8 +693,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[1]/Skeleton[0]",
@@ -758,8 +706,7 @@
 			"weight": 1,
 			"props": [
 				"width"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Description[2]",
@@ -770,8 +717,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Description[2]/Skeleton[0]",
@@ -782,8 +728,7 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[3]",
@@ -796,8 +741,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCardSkeleton/Card[0]/StyledContent[1]/Body[3]/Skeleton[0]",
@@ -812,8 +756,7 @@
 				"width",
 				"height",
 				"style"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "RestaurantCard/RestaurantCardSkeleton[0]",
@@ -824,8 +767,7 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 1,
-			"props": [],
-			"instances": 1.5
+			"props": []
 		},
 		{
 			"path": "RestaurantCard/Card[0]",
@@ -841,8 +783,7 @@
 				"className",
 				"data-testid",
 				"onClick"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/NewBadge[0]",
@@ -856,8 +797,7 @@
 			"props": [
 				"text",
 				"variant"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Closed[0]/Body[0]",
@@ -870,8 +810,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/StyledHeading[0]",
@@ -885,8 +824,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/Review[1]",
@@ -899,8 +837,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Card[0]/StyledContent[1]/Description[2]",
@@ -913,8 +850,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/StyledBadge[0]",
@@ -928,8 +864,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1.5
+			]
 		},
 		{
 			"path": "RestaurantCard/Body[0]",
@@ -942,8 +877,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Heading[0]",
@@ -956,8 +890,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Review[1]",
@@ -970,8 +903,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/div[0]/div[1]/Body[2]",
@@ -984,8 +916,7 @@
 			"weight": 1,
 			"props": [
 				"fontWeight"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantCard/Badge[0]",
@@ -999,8 +930,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Review/Wrapper[0]/StyledBody[0]",
@@ -1015,8 +945,7 @@
 				"size",
 				"type",
 				"className"
-			],
-			"instances": 3.5
+			]
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]",
@@ -1027,8 +956,7 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/StyledHeading[0]",
@@ -1043,8 +971,7 @@
 				"level",
 				"size",
 				"$withMargin"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "OrderSummary/ShoppingCartItem[0]",
@@ -1058,8 +985,7 @@
 			"props": [
 				"key",
 				"item"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "OrderSummary/Body[0]",
@@ -1070,8 +996,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 0.5,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/Body[0]",
@@ -1082,8 +1007,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 2
+			"props": []
 		},
 		{
 			"path": "OrderSummary/OrderSummaryContainer[0]/BottomContainer[2]/TotalHeading[1]",
@@ -1097,8 +1021,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 2
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Quantity[0]",
@@ -1111,8 +1034,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Name[1]",
@@ -1125,8 +1047,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ShoppingCartItem/CartItemContainer[0]/Price[2]",
@@ -1139,8 +1060,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[0]",
@@ -1153,8 +1073,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/TotalSection[0]/Body[1]",
@@ -1167,8 +1086,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Footer/FooterContainer[0]/Button[1]",
@@ -1183,8 +1101,7 @@
 				"disabled",
 				"large",
 				"onClick"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[0]",
@@ -1198,8 +1115,7 @@
 			"props": [
 				"type",
 				"fontWeight"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[1]",
@@ -1210,8 +1126,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/div[0]/Body[2]",
@@ -1222,8 +1137,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 27
+			"props": []
 		},
 		{
 			"path": "ShoppingCartMenuItem/MenuItemContainer[0]/Select[1]",
@@ -1239,8 +1153,7 @@
 				"onChange",
 				"aria-label",
 				"options"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Sidebar[0]",
@@ -1257,8 +1170,7 @@
 				"isOpen",
 				"container",
 				"footer"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/Footer[0]",
@@ -1272,8 +1184,7 @@
 			"props": [
 				"onClick",
 				"totalPrice"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "ShoppingCartMenu/ShoppingCartMenuItem[0]",
@@ -1288,8 +1199,7 @@
 				"key",
 				"item",
 				"onChange"
-			],
-			"instances": 27
+			]
 		},
 		{
 			"path": "Input/Wrapper[0]/DsInput[0]",
@@ -1302,8 +1212,7 @@
 			"weight": 1,
 			"props": [
 				"..."
-			],
-			"instances": 7
+			]
 		},
 		{
 			"path": "<module>/StrictMode[0]",
@@ -1314,8 +1223,7 @@
 			"module": "react",
 			"name": "StrictMode",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "<module>/StrictMode[0]/App[0]",
@@ -1326,8 +1234,7 @@
 			"module": "src/App.tsx",
 			"name": "App",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]",
@@ -1338,8 +1245,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/TopBanner[0]",
@@ -1354,8 +1260,7 @@
 				"title",
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/PageTemplate[0]/div[1]/Breadcrumb[0]",
@@ -1368,8 +1273,7 @@
 			"weight": 1,
 			"props": [
 				"items"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "render/Link[0]",
@@ -1382,8 +1286,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/ErrorBlock[0]",
@@ -1400,8 +1303,7 @@
 				"illustration",
 				"buttonText",
 				"onButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCardSkeleton[0]",
@@ -1414,8 +1316,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryDetailPage/RestaurantCard[0]",
@@ -1430,8 +1331,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]",
@@ -1442,8 +1342,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/TopBanner[0]",
@@ -1457,8 +1356,7 @@
 			"props": [
 				"title",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledHeading[0]",
@@ -1471,8 +1369,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/StyledBody[1]",
@@ -1483,8 +1380,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoryListPage/PageTemplate[0]/div[1]/CategoryList[2]",
@@ -1497,8 +1393,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]",
@@ -1512,8 +1407,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoryList/Link[0]/Category[0]",
@@ -1527,8 +1421,7 @@
 			"props": [
 				"...",
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]",
@@ -1541,8 +1434,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/TopContainer[0]/StyledHeading[0]",
@@ -1556,8 +1448,7 @@
 			"props": [
 				"level",
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/MultiStepForm[0]",
@@ -1568,8 +1459,7 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/MultiStepForm.tsx",
 			"name": "MultiStepForm",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CheckoutPage/PageTemplate[0]/ContentContainer[0]/BottomContainer[1]/OrderDetailsContainer[1]/OrderSummary[0]",
@@ -1582,8 +1472,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[0]",
@@ -1601,8 +1490,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[1]",
@@ -1620,8 +1508,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[2]",
@@ -1640,8 +1527,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/Input[3]",
@@ -1660,8 +1546,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/DisclaimerText[4]",
@@ -1675,8 +1560,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "ContactDetails/div[0]/div[5]/Button[0]",
@@ -1689,8 +1573,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[0]",
@@ -1708,8 +1591,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[1]",
@@ -1727,8 +1609,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/Input[2]",
@@ -1746,8 +1627,7 @@
 				"value",
 				"onChange",
 				"error"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[0]",
@@ -1761,8 +1641,7 @@
 			"props": [
 				"clear",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "DeliveryDetails/div[0]/div[3]/Button[1]",
@@ -1775,8 +1654,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/ContactDetails[0]",
@@ -1791,8 +1669,7 @@
 				"formData",
 				"setFormData",
 				"onNext"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "renderCurrentStep/DeliveryDetails[0]",
@@ -1807,8 +1684,7 @@
 				"formData",
 				"setFormData",
 				"onPrevious"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "MultiStepForm/FormContainer[0]/StepIndicator[0]",
@@ -1823,8 +1699,7 @@
 				"title",
 				"currentStep",
 				"amountOfSteps"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Heading[0]",
@@ -1838,8 +1713,7 @@
 			"props": [
 				"level",
 				"size"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "StepIndicator/div[0]/TitleSection[0]/Body[1]",
@@ -1853,8 +1727,7 @@
 			"props": [
 				"size",
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]",
@@ -1865,8 +1738,7 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/Banner[0]",
@@ -1877,8 +1749,7 @@
 			"module": "src/pages/HomePage/components/Banner/Banner.tsx",
 			"name": "Banner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/RestaurantsSection[2]",
@@ -1891,8 +1762,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/AwardWinningSection[4]",
@@ -1903,8 +1773,7 @@
 			"module": "src/pages/HomePage/components/AwardWinningSection/AwardWinningSection.tsx",
 			"name": "AwardWinningSection",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "HomePage/PageTemplate[0]/CategoriesSection[6]",
@@ -1917,8 +1786,7 @@
 			"weight": 1,
 			"props": [
 				"categories"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[0]",
@@ -1931,8 +1799,7 @@
 			"weight": 1,
 			"props": [
 				"className"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Heading[1]",
@@ -1943,8 +1810,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]",
@@ -1957,8 +1823,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "AwardWinningSection/Container[0]/ContentContainer[0]/LeftContainer[0]/Link[2]/StyledButton[0]",
@@ -1969,8 +1834,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/StyledHeading[0]",
@@ -1983,8 +1847,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]",
@@ -1997,8 +1860,7 @@
 			"weight": 1,
 			"props": [
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "Banner/Container[0]/ContentContainer[0]/Link[1]/Button[0]",
@@ -2009,8 +1871,7 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]",
@@ -2025,8 +1886,7 @@
 				"title",
 				"topButtonLabel",
 				"onTopButtonClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/PageSection[0]/Carousel[0]",
@@ -2040,8 +1900,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]",
@@ -2055,8 +1914,7 @@
 			"props": [
 				"key",
 				"to"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "CategoriesSection/StyledLink[0]/Category[0]",
@@ -2070,8 +1928,7 @@
 			"props": [
 				"round",
 				"..."
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]",
@@ -2084,8 +1941,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/PageSection[0]/Carousel[0]",
@@ -2099,8 +1955,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCardSkeleton[0]",
@@ -2113,8 +1968,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSectionComponent/RestaurantCard[0]",
@@ -2129,8 +1983,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantsSectionComponent[0]",
@@ -2146,8 +1999,7 @@
 				"restaurants",
 				"isLoading",
 				"onRestaurantClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]",
@@ -2160,8 +2012,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/PageSection[0]/Carousel[0]",
@@ -2175,8 +2026,7 @@
 			"props": [
 				"itemsPerView",
 				"slidesToScroll"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCardSkeleton[0]",
@@ -2189,8 +2039,7 @@
 			"weight": 0.5,
 			"props": [
 				"key"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantsSection/RestaurantCard[0]",
@@ -2205,8 +2054,7 @@
 				"key",
 				"...",
 				"onClick"
-			],
-			"instances": 0.5
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]",
@@ -2219,8 +2067,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]",
@@ -2237,8 +2084,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]",
@@ -2251,8 +2097,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#2",
@@ -2265,8 +2110,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/ErrorBlock[0]#2",
@@ -2283,8 +2127,7 @@
 				"illustration",
 				"onButtonClick",
 				"buttonText"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/AnimatedIllustration[0]#2",
@@ -2297,8 +2140,7 @@
 			"weight": 1,
 			"props": [
 				"animation"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#3",
@@ -2311,8 +2153,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/Spinner[0]",
@@ -2323,8 +2164,7 @@
 			"module": "src/components/Spinner/Spinner.tsx",
 			"name": "Spinner",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]#4",
@@ -2337,8 +2177,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/FoodItemModal[0]",
@@ -2355,8 +2194,7 @@
 				"onClose",
 				"onItemSave",
 				"onItemRemove"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/TopBanner[1]",
@@ -2370,8 +2208,7 @@
 			"props": [
 				"photoUrl",
 				"onBackClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Heading[0]",
@@ -2384,8 +2221,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Body[1]",
@@ -2396,8 +2232,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "RestaurantDetailPage/PageTemplate[0]/DetailSection[2]/div[0]/Review[2]",
@@ -2410,8 +2245,7 @@
 			"weight": 1,
 			"props": [
 				"rating"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/StyledBadge[0]",
@@ -2425,8 +2259,7 @@
 			"props": [
 				"key",
 				"text"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]",
@@ -2442,8 +2275,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#2",
@@ -2459,8 +2291,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "RestaurantDetailPage/FoodSection[0]#3",
@@ -2476,8 +2307,7 @@
 				"items",
 				"cartItems",
 				"onItemClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]",
@@ -2490,8 +2320,7 @@
 			"weight": 1,
 			"props": [
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Quantity[0]",
@@ -2506,8 +2335,7 @@
 				"aria-label",
 				"type",
 				"fontWeight"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Heading[0]",
@@ -2520,8 +2348,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Description[1]",
@@ -2532,8 +2359,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItem/Container[0]/div[0]/Price[2]",
@@ -2544,8 +2370,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 3
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/Modal[0]",
@@ -2560,8 +2385,7 @@
 				"isOpen",
 				"onClose",
 				"container"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/Heading[0]",
@@ -2572,8 +2396,7 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/TopContainer[0]/StyledBody[1]",
@@ -2584,8 +2407,7 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": [],
-			"instances": 1
+			"props": []
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/ButtonsContainer[0]/QuantityStepper[0]",
@@ -2601,8 +2423,7 @@
 				"onChange",
 				"min",
 				"max"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodItemModal/div[0]/BottomContainer[1]/StyledButton[1]",
@@ -2616,8 +2437,7 @@
 			"props": [
 				"aria-label",
 				"onClick"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "FoodSection/div[0]/StyledHeading[0]",
@@ -2630,8 +2450,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "FoodSection/FoodItem[0]",
@@ -2649,8 +2468,7 @@
 				"description",
 				"quantity",
 				"onClick"
-			],
-			"instances": 3
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]",
@@ -2663,8 +2481,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/TopBanner[0]",
@@ -2677,8 +2494,7 @@
 			"weight": 1,
 			"props": [
 				"title"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/Body[0]",
@@ -2691,8 +2507,7 @@
 			"weight": 1,
 			"props": [
 				"type"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/StyledHeading[1]",
@@ -2705,8 +2520,7 @@
 			"weight": 1,
 			"props": [
 				"level"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "SuccessPage/PageTemplate[0]/Container[0]/OrderSummaryContainer[1]/OrderSummary[2]",
@@ -2719,8 +2533,7 @@
 			"weight": 1,
 			"props": [
 				"cartItems"
-			],
-			"instances": 1
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]",
@@ -2733,8 +2546,7 @@
 			"weight": 1,
 			"props": [
 				"sticky"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Footer[0]",
@@ -2745,8 +2557,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/HeaderComponent[0]",
@@ -2759,8 +2570,7 @@
 			"weight": 1,
 			"props": [
 				"logoOnly"
-			],
-			"instances": 9
+			]
 		},
 		{
 			"path": "PageTemplate/Header[0]#2",
@@ -2771,8 +2581,7 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		},
 		{
 			"path": "PageTemplate/Footer[0]#2",
@@ -2783,8 +2592,7 @@
 			"module": "src/components/Footer/Footer.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": [],
-			"instances": 9
+			"props": []
 		}
 	]
 }

--- a/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
+++ b/agent-eval/baselines/ds-nodes/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
@@ -24,7 +24,9 @@
 			"module": "react-redux",
 			"name": "Provider",
 			"weight": 1,
-			"props": ["store"],
+			"props": [
+				"store"
+			],
 			"instances": 1
 		},
 		{
@@ -36,7 +38,9 @@
 			"module": "styled-components",
 			"name": "ThemeProvider",
 			"weight": 1,
-			"props": ["theme"],
+			"props": [
+				"theme"
+			],
 			"instances": 1
 		},
 		{
@@ -84,7 +88,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -108,7 +115,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -132,7 +142,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -156,7 +169,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -180,7 +196,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -204,7 +223,10 @@
 			"module": "react-router-dom",
 			"name": "Route",
 			"weight": 1,
-			"props": ["path", "element"],
+			"props": [
+				"path",
+				"element"
+			],
 			"instances": 1
 		},
 		{
@@ -228,7 +250,12 @@
 			"module": "react-lottie-player",
 			"name": "default",
 			"weight": 1,
-			"props": ["style", "play", "loop", "animationData"],
+			"props": [
+				"style",
+				"play",
+				"loop",
+				"animationData"
+			],
 			"instances": 2
 		},
 		{
@@ -240,7 +267,11 @@
 			"module": "@droppy/design-system",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -252,7 +283,11 @@
 			"module": "@droppy/design-system",
 			"name": "IconButton",
 			"weight": 1,
-			"props": ["name", "aria-label", "onClick"],
+			"props": [
+				"name",
+				"aria-label",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -264,7 +299,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 1
 		},
 		{
@@ -276,7 +313,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -288,7 +327,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -300,7 +342,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Rounded",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -312,7 +357,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Squared",
 			"weight": 0.5,
-			"props": ["photoUrl", "title"],
+			"props": [
+				"photoUrl",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -324,7 +372,10 @@
 			"module": "src/components/Logo/Logo.tsx",
 			"name": "Logo",
 			"weight": 1,
-			"props": ["large", "logoOnly"],
+			"props": [
+				"large",
+				"logoOnly"
+			],
 			"instances": 18
 		},
 		{
@@ -336,7 +387,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -348,7 +402,10 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title", "links"],
+			"props": [
+				"title",
+				"links"
+			],
 			"instances": 18
 		},
 		{
@@ -360,7 +417,9 @@
 			"module": "src/components/FooterCard/FooterCard.tsx",
 			"name": "FooterCard",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 18
 		},
 		{
@@ -372,7 +431,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 54
 		},
 		{
@@ -396,7 +457,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 0.5,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 27
 		},
 		{
@@ -408,7 +471,13 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["round", "clear", "aria-label", "icon", "onClick"],
+			"props": [
+				"round",
+				"clear",
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -420,7 +489,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "aria-label"],
+			"props": [
+				"to",
+				"aria-label"
+			],
 			"instances": 27
 		},
 		{
@@ -456,7 +528,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -468,7 +543,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -480,7 +557,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to", "tabIndex"],
+			"props": [
+				"to",
+				"tabIndex"
+			],
 			"instances": 27
 		},
 		{
@@ -492,7 +572,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear"],
+			"props": [
+				"clear"
+			],
 			"instances": 27
 		},
 		{
@@ -504,7 +586,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "icon", "onClick"],
+			"props": [
+				"aria-label",
+				"icon",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -516,7 +602,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -528,7 +616,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -579,7 +669,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 45
 		},
 		{
@@ -591,7 +684,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["data-testid"],
+			"props": [
+				"data-testid"
+			],
 			"instances": 3
 		},
 		{
@@ -603,7 +698,10 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["height", "width"],
+			"props": [
+				"height",
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -615,7 +713,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 3
 		},
 		{
@@ -627,7 +728,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -639,7 +742,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -651,7 +756,9 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width"],
+			"props": [
+				"width"
+			],
 			"instances": 3
 		},
 		{
@@ -687,7 +794,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 3
 		},
 		{
@@ -699,7 +808,11 @@
 			"module": "@droppy/design-system",
 			"name": "Skeleton",
 			"weight": 1,
-			"props": ["width", "height", "style"],
+			"props": [
+				"width",
+				"height",
+				"style"
+			],
 			"instances": 3
 		},
 		{
@@ -723,7 +836,12 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["interactive", "className", "data-testid", "onClick"],
+			"props": [
+				"interactive",
+				"className",
+				"data-testid",
+				"onClick"
+			],
 			"instances": 1.5
 		},
 		{
@@ -735,7 +853,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["text", "variant"],
+			"props": [
+				"text",
+				"variant"
+			],
 			"instances": 1.5
 		},
 		{
@@ -747,7 +868,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1.5
 		},
 		{
@@ -759,7 +882,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1.5
 		},
 		{
@@ -771,7 +897,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1.5
 		},
 		{
@@ -783,7 +911,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1.5
 		},
 		{
@@ -795,7 +925,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1.5
 		},
 		{
@@ -807,7 +940,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -819,7 +954,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -831,7 +968,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -843,7 +982,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["fontWeight"],
+			"props": [
+				"fontWeight"
+			],
 			"instances": 1
 		},
 		{
@@ -855,7 +996,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -867,7 +1011,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type", "className"],
+			"props": [
+				"size",
+				"type",
+				"className"
+			],
 			"instances": 3.5
 		},
 		{
@@ -891,7 +1039,11 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size", "$withMargin"],
+			"props": [
+				"level",
+				"size",
+				"$withMargin"
+			],
 			"instances": 2
 		},
 		{
@@ -903,7 +1055,10 @@
 			"module": "src/components/ShoppingCart/ShoppingCartItem/ShoppingCartItem.tsx",
 			"name": "ShoppingCartItem",
 			"weight": 0.5,
-			"props": ["key", "item"],
+			"props": [
+				"key",
+				"item"
+			],
 			"instances": 1
 		},
 		{
@@ -939,7 +1094,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 2
 		},
 		{
@@ -951,7 +1109,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -963,7 +1123,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -975,7 +1137,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -987,7 +1151,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -999,7 +1165,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 27
 		},
 		{
@@ -1011,7 +1179,11 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["disabled", "large", "onClick"],
+			"props": [
+				"disabled",
+				"large",
+				"onClick"
+			],
 			"instances": 27
 		},
 		{
@@ -1023,7 +1195,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type", "fontWeight"],
+			"props": [
+				"type",
+				"fontWeight"
+			],
 			"instances": 27
 		},
 		{
@@ -1059,7 +1234,12 @@
 			"module": "@droppy/design-system",
 			"name": "Select",
 			"weight": 1,
-			"props": ["value", "onChange", "aria-label", "options"],
+			"props": [
+				"value",
+				"onChange",
+				"aria-label",
+				"options"
+			],
 			"instances": 27
 		},
 		{
@@ -1071,7 +1251,13 @@
 			"module": "@droppy/design-system",
 			"name": "Sidebar",
 			"weight": 1,
-			"props": ["title", "onClose", "isOpen", "container", "footer"],
+			"props": [
+				"title",
+				"onClose",
+				"isOpen",
+				"container",
+				"footer"
+			],
 			"instances": 27
 		},
 		{
@@ -1083,7 +1269,10 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "Footer",
 			"weight": 1,
-			"props": ["onClick", "totalPrice"],
+			"props": [
+				"onClick",
+				"totalPrice"
+			],
 			"instances": 27
 		},
 		{
@@ -1095,7 +1284,11 @@
 			"module": "src/components/ShoppingCartMenu/ShoppingCartMenu.tsx",
 			"name": "ShoppingCartMenuItem",
 			"weight": 1,
-			"props": ["key", "item", "onChange"],
+			"props": [
+				"key",
+				"item",
+				"onChange"
+			],
 			"instances": 27
 		},
 		{
@@ -1107,7 +1300,9 @@
 			"module": "@droppy/design-system",
 			"name": "Input",
 			"weight": 1,
-			"props": ["..."],
+			"props": [
+				"..."
+			],
 			"instances": 7
 		},
 		{
@@ -1155,7 +1350,11 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "photoUrl", "onBackClick"],
+			"props": [
+				"title",
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1167,7 +1366,9 @@
 			"module": "@droppy/design-system",
 			"name": "Breadcrumb",
 			"weight": 1,
-			"props": ["items"],
+			"props": [
+				"items"
+			],
 			"instances": 1
 		},
 		{
@@ -1179,7 +1380,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1191,7 +1394,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["body", "title", "illustration", "buttonText", "onButtonClick"],
+			"props": [
+				"body",
+				"title",
+				"illustration",
+				"buttonText",
+				"onButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1203,7 +1412,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1215,7 +1426,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1239,7 +1454,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title", "onBackClick"],
+			"props": [
+				"title",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1251,7 +1469,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1275,7 +1495,9 @@
 			"module": "src/pages/CategoryListPage/components/CategoryList/CategoryList.tsx",
 			"name": "CategoryList",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1287,7 +1509,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1299,7 +1524,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["...", "title"],
+			"props": [
+				"...",
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1311,7 +1539,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1323,7 +1553,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "className"],
+			"props": [
+				"level",
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1347,7 +1580,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -1359,7 +1594,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1371,7 +1613,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1383,7 +1632,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "type", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"type",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1395,7 +1652,15 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "type", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"type",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1407,7 +1672,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1419,7 +1687,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1431,7 +1701,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1443,7 +1720,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1455,7 +1739,14 @@
 			"module": "src/components/forms/Input.tsx",
 			"name": "Input",
 			"weight": 1,
-			"props": ["label", "placeholder", "name", "value", "onChange", "error"],
+			"props": [
+				"label",
+				"placeholder",
+				"name",
+				"value",
+				"onChange",
+				"error"
+			],
 			"instances": 1
 		},
 		{
@@ -1467,7 +1758,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["clear", "onClick"],
+			"props": [
+				"clear",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1479,7 +1773,9 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1491,7 +1787,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/ContactDetails.tsx",
 			"name": "ContactDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onNext"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onNext"
+			],
 			"instances": 1
 		},
 		{
@@ -1503,7 +1803,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/DeliveryDetails.tsx",
 			"name": "DeliveryDetails",
 			"weight": 1,
-			"props": ["formData", "setFormData", "onPrevious"],
+			"props": [
+				"formData",
+				"setFormData",
+				"onPrevious"
+			],
 			"instances": 1
 		},
 		{
@@ -1515,7 +1819,11 @@
 			"module": "src/pages/CheckoutPage/components/registration-form/StepIndicator.tsx",
 			"name": "StepIndicator",
 			"weight": 1,
-			"props": ["title", "currentStep", "amountOfSteps"],
+			"props": [
+				"title",
+				"currentStep",
+				"amountOfSteps"
+			],
 			"instances": 1
 		},
 		{
@@ -1527,7 +1835,10 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level", "size"],
+			"props": [
+				"level",
+				"size"
+			],
 			"instances": 1
 		},
 		{
@@ -1539,7 +1850,10 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["size", "type"],
+			"props": [
+				"size",
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1575,7 +1889,9 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.tsx",
 			"name": "RestaurantsSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1599,7 +1915,9 @@
 			"module": "src/pages/HomePage/components/CategoriesSection/CategoriesSection.tsx",
 			"name": "CategoriesSection",
 			"weight": 1,
-			"props": ["categories"],
+			"props": [
+				"categories"
+			],
 			"instances": 1
 		},
 		{
@@ -1611,7 +1929,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["className"],
+			"props": [
+				"className"
+			],
 			"instances": 1
 		},
 		{
@@ -1635,7 +1955,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1659,7 +1981,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -1671,7 +1995,9 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["to"],
+			"props": [
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1695,7 +2021,11 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title", "topButtonLabel", "onTopButtonClick"],
+			"props": [
+				"title",
+				"topButtonLabel",
+				"onTopButtonClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1707,7 +2037,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1719,7 +2052,10 @@
 			"module": "react-router-dom",
 			"name": "Link",
 			"weight": 1,
-			"props": ["key", "to"],
+			"props": [
+				"key",
+				"to"
+			],
 			"instances": 1
 		},
 		{
@@ -1731,7 +2067,10 @@
 			"module": "src/components/Category/Category.tsx",
 			"name": "Category",
 			"weight": 1,
-			"props": ["round", "..."],
+			"props": [
+				"round",
+				"..."
+			],
 			"instances": 1
 		},
 		{
@@ -1743,7 +2082,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1755,7 +2096,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1767,7 +2111,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1779,7 +2125,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1791,7 +2141,12 @@
 			"module": "src/pages/HomePage/components/RestaurantsSection/RestaurantsSection.container.tsx",
 			"name": "RestaurantsSectionComponent",
 			"weight": 1,
-			"props": ["title", "restaurants", "isLoading", "onRestaurantClick"],
+			"props": [
+				"title",
+				"restaurants",
+				"isLoading",
+				"onRestaurantClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1803,7 +2158,9 @@
 			"module": "@droppy/design-system",
 			"name": "PageSection",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -1815,7 +2172,10 @@
 			"module": "src/components/Carousel/Carousel.tsx",
 			"name": "Carousel",
 			"weight": 1,
-			"props": ["itemsPerView", "slidesToScroll"],
+			"props": [
+				"itemsPerView",
+				"slidesToScroll"
+			],
 			"instances": 1
 		},
 		{
@@ -1827,7 +2187,9 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCardSkeleton",
 			"weight": 0.5,
-			"props": ["key"],
+			"props": [
+				"key"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1839,7 +2201,11 @@
 			"module": "src/components/RestaurantCard/RestaurantCard.tsx",
 			"name": "RestaurantCard",
 			"weight": 0.5,
-			"props": ["key", "...", "onClick"],
+			"props": [
+				"key",
+				"...",
+				"onClick"
+			],
 			"instances": 0.5
 		},
 		{
@@ -1851,7 +2217,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1863,7 +2231,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1875,7 +2249,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1887,7 +2263,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1899,7 +2277,13 @@
 			"module": "@droppy/design-system",
 			"name": "ErrorBlock",
 			"weight": 1,
-			"props": ["title", "body", "illustration", "onButtonClick", "buttonText"],
+			"props": [
+				"title",
+				"body",
+				"illustration",
+				"onButtonClick",
+				"buttonText"
+			],
 			"instances": 1
 		},
 		{
@@ -1911,7 +2295,9 @@
 			"module": "src/components/AnimatedIllustration/AnimatedIllustration.tsx",
 			"name": "AnimatedIllustration",
 			"weight": 1,
-			"props": ["animation"],
+			"props": [
+				"animation"
+			],
 			"instances": 1
 		},
 		{
@@ -1923,7 +2309,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1947,7 +2335,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -1959,7 +2349,13 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItemModal/FoodItemModal.tsx",
 			"name": "FoodItemModal",
 			"weight": 1,
-			"props": ["item", "cartItems", "onClose", "onItemSave", "onItemRemove"],
+			"props": [
+				"item",
+				"cartItems",
+				"onClose",
+				"onItemSave",
+				"onItemRemove"
+			],
 			"instances": 1
 		},
 		{
@@ -1971,7 +2367,10 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["photoUrl", "onBackClick"],
+			"props": [
+				"photoUrl",
+				"onBackClick"
+			],
 			"instances": 1
 		},
 		{
@@ -1983,7 +2382,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2007,7 +2408,9 @@
 			"module": "src/components/Review/Review.tsx",
 			"name": "Review",
 			"weight": 1,
-			"props": ["rating"],
+			"props": [
+				"rating"
+			],
 			"instances": 1
 		},
 		{
@@ -2019,7 +2422,10 @@
 			"module": "@droppy/design-system",
 			"name": "Badge",
 			"weight": 1,
-			"props": ["key", "text"],
+			"props": [
+				"key",
+				"text"
+			],
 			"instances": 1
 		},
 		{
@@ -2031,7 +2437,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2043,7 +2454,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2055,7 +2471,12 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodSection/FoodSection.tsx",
 			"name": "FoodSection",
 			"weight": 1,
-			"props": ["title", "items", "cartItems", "onItemClick"],
+			"props": [
+				"title",
+				"items",
+				"cartItems",
+				"onItemClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2067,7 +2488,9 @@
 			"module": "@droppy/design-system",
 			"name": "Card",
 			"weight": 1,
-			"props": ["onClick"],
+			"props": [
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2079,7 +2502,11 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["aria-label", "type", "fontWeight"],
+			"props": [
+				"aria-label",
+				"type",
+				"fontWeight"
+			],
 			"instances": 3
 		},
 		{
@@ -2091,7 +2518,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2127,7 +2556,11 @@
 			"module": "@droppy/design-system",
 			"name": "Modal",
 			"weight": 1,
-			"props": ["isOpen", "onClose", "container"],
+			"props": [
+				"isOpen",
+				"onClose",
+				"container"
+			],
 			"instances": 1
 		},
 		{
@@ -2163,7 +2596,12 @@
 			"module": "@droppy/design-system",
 			"name": "QuantityStepper",
 			"weight": 1,
-			"props": ["value", "onChange", "min", "max"],
+			"props": [
+				"value",
+				"onChange",
+				"min",
+				"max"
+			],
 			"instances": 1
 		},
 		{
@@ -2175,7 +2613,10 @@
 			"module": "@droppy/design-system",
 			"name": "Button",
 			"weight": 1,
-			"props": ["aria-label", "onClick"],
+			"props": [
+				"aria-label",
+				"onClick"
+			],
 			"instances": 1
 		},
 		{
@@ -2187,7 +2628,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 3
 		},
 		{
@@ -2199,7 +2642,14 @@
 			"module": "src/pages/RestaurantDetailPage/components/FoodItem/FoodItem.tsx",
 			"name": "FoodItem",
 			"weight": 1,
-			"props": ["key", "name", "price", "description", "quantity", "onClick"],
+			"props": [
+				"key",
+				"name",
+				"price",
+				"description",
+				"quantity",
+				"onClick"
+			],
 			"instances": 3
 		},
 		{
@@ -2211,7 +2661,9 @@
 			"module": "src/templates/PageTemplate.tsx",
 			"name": "PageTemplate",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2223,7 +2675,9 @@
 			"module": "@droppy/design-system",
 			"name": "TopBanner",
 			"weight": 1,
-			"props": ["title"],
+			"props": [
+				"title"
+			],
 			"instances": 1
 		},
 		{
@@ -2235,7 +2689,9 @@
 			"module": "@droppy/design-system",
 			"name": "Body",
 			"weight": 1,
-			"props": ["type"],
+			"props": [
+				"type"
+			],
 			"instances": 1
 		},
 		{
@@ -2247,7 +2703,9 @@
 			"module": "@droppy/design-system",
 			"name": "Heading",
 			"weight": 1,
-			"props": ["level"],
+			"props": [
+				"level"
+			],
 			"instances": 1
 		},
 		{
@@ -2259,7 +2717,9 @@
 			"module": "src/components/ShoppingCart/OrderSummary/OrderSummary.tsx",
 			"name": "OrderSummary",
 			"weight": 1,
-			"props": ["cartItems"],
+			"props": [
+				"cartItems"
+			],
 			"instances": 1
 		},
 		{
@@ -2271,7 +2731,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "Header",
 			"weight": 1,
-			"props": ["sticky"],
+			"props": [
+				"sticky"
+			],
 			"instances": 9
 		},
 		{
@@ -2295,7 +2757,9 @@
 			"module": "src/components/Header/Header.tsx",
 			"name": "HeaderComponent",
 			"weight": 1,
-			"props": ["logoOnly"],
+			"props": [
+				"logoOnly"
+			],
 			"instances": 9
 		},
 		{

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
@@ -1298,7 +1298,10 @@
 		},
 		"parseFailures": [],
 		"dsCoverage": {
-			"dsPackages": ["@base-ui/react", "@droppy/*"],
+			"dsPackages": [
+				"@base-ui/react",
+				"@droppy/*"
+			],
 			"files": 127,
 			"nodes": {
 				"all": 365.5,

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__base-ui-v1.json
@@ -2,7 +2,7 @@
 	"repo": "yannbf/mealdrop",
 	"ref": "refs/tags/agentic-reference/base-ui-v1",
 	"metricsVersion": 8,
-	"nodeSidecar": true,
+	"nodeCensus": true,
 	"analysis": {
 		"files": {
 			"functions/restaurants.ts": {

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
@@ -968,7 +968,9 @@
 		},
 		"parseFailures": [],
 		"dsCoverage": {
-			"dsPackages": ["@droppy/*"],
+			"dsPackages": [
+				"@droppy/*"
+			],
 			"files": 94,
 			"nodes": {
 				"all": 278,
@@ -983,16 +985,16 @@
 			"dsShareOfComponentNodes": 0.6921,
 			"instances": {
 				"nodes": {
-					"all": 427,
-					"host": 146,
-					"component": 281,
-					"ds": 208.5,
-					"external": 15,
-					"local": 57.5,
+					"all": 683,
+					"host": 258,
+					"component": 425,
+					"ds": 244.5,
+					"external": 54,
+					"local": 126.5,
 					"unresolved": 0
 				},
-				"dsShareOfAllNodes": 0.4883,
-				"dsShareOfComponentNodes": 0.742
+				"dsShareOfAllNodes": 0.358,
+				"dsShareOfComponentNodes": 0.5753
 			},
 			"parseFailures": [],
 			"readFailures": []

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v2.json
@@ -2,7 +2,7 @@
 	"repo": "yannbf/mealdrop",
 	"ref": "refs/tags/agentic-reference/droppy-70pc-v2",
 	"metricsVersion": 8,
-	"nodeSidecar": true,
+	"nodeCensus": true,
 	"analysis": {
 		"files": {
 			"functions/restaurants.ts": {

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
@@ -2,7 +2,7 @@
 	"repo": "yannbf/mealdrop",
 	"ref": "refs/tags/agentic-reference/droppy-70pc-v4",
 	"metricsVersion": 8,
-	"nodeSidecar": true,
+	"nodeCensus": true,
 	"analysis": {
 		"files": {
 			"functions/restaurants.ts": {

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-70pc-v4.json
@@ -958,7 +958,9 @@
 		},
 		"parseFailures": [],
 		"dsCoverage": {
-			"dsPackages": ["@droppy/*"],
+			"dsPackages": [
+				"@droppy/*"
+			],
 			"files": 93,
 			"nodes": {
 				"all": 279,
@@ -973,16 +975,16 @@
 			"dsShareOfComponentNodes": 0.6905,
 			"instances": {
 				"nodes": {
-					"all": 428,
-					"host": 148.5,
-					"component": 279.5,
-					"ds": 207,
-					"external": 15,
-					"local": 57.5,
+					"all": 684,
+					"host": 260.5,
+					"component": 423.5,
+					"ds": 243,
+					"external": 54,
+					"local": 126.5,
 					"unresolved": 0
 				},
-				"dsShareOfAllNodes": 0.4836,
-				"dsShareOfComponentNodes": 0.7406
+				"dsShareOfAllNodes": 0.3553,
+				"dsShareOfComponentNodes": 0.5738
 			},
 			"parseFailures": [],
 			"readFailures": []

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
@@ -2,7 +2,7 @@
 	"repo": "yannbf/mealdrop",
 	"ref": "refs/tags/agentic-reference/droppy-v2",
 	"metricsVersion": 8,
-	"nodeSidecar": true,
+	"nodeCensus": true,
 	"analysis": {
 		"files": {
 			"functions/restaurants.ts": {

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v2.json
@@ -1028,7 +1028,9 @@
 		},
 		"parseFailures": [],
 		"dsCoverage": {
-			"dsPackages": ["@droppy/*"],
+			"dsPackages": [
+				"@droppy/*"
+			],
 			"files": 100,
 			"nodes": {
 				"all": 312,

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
@@ -2,7 +2,7 @@
 	"repo": "yannbf/mealdrop",
 	"ref": "refs/tags/agentic-reference/droppy-v3",
 	"metricsVersion": 8,
-	"nodeSidecar": true,
+	"nodeCensus": true,
 	"analysis": {
 		"files": {
 			"functions/restaurants.ts": {

--- a/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
+++ b/agent-eval/baselines/yannbf__mealdrop@refs__tags__agentic-reference__droppy-v3.json
@@ -1028,7 +1028,9 @@
 		},
 		"parseFailures": [],
 		"dsCoverage": {
-			"dsPackages": ["@droppy/*"],
+			"dsPackages": [
+				"@droppy/*"
+			],
 			"files": 100,
 			"nodes": {
 				"all": 312,

--- a/agent-eval/lib/agentic-reference/metrics/coverage.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/coverage.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import { coverageDelta, isDsCoverage } from './coverage.ts';
+import { round } from '../../utils/math.ts';
 
 import type { DsCoverage } from './coverage.ts';
 
 function slice(ds: number, instanceDs: number | null): DsCoverage {
 	const nodes = { all: 10, host: 4, component: 6, ds, external: 0, local: 6 - ds, unresolved: 0 };
+	// The instance view scales the whole tree up (JSX inside a reused component
+	// counts once per instantiation), so its totals are a separate, internally
+	// consistent NodeTotals — not the static one with only `ds` and `all`
+	// overridden, which would leave `all` disagreeing with `host + component`
+	// and let `ds` exceed `component`.
+	const instanceComponent = 12;
+	const instanceHost = 8;
 	return {
 		dsPackages: ['@ds/*'],
 		files: 2,
@@ -18,9 +26,17 @@ function slice(ds: number, instanceDs: number | null): DsCoverage {
 			? {}
 			: {
 					instances: {
-						nodes: { ...nodes, ds: instanceDs, all: 20 },
-						dsShareOfAllNodes: instanceDs / 20,
-						dsShareOfComponentNodes: instanceDs / 6,
+						nodes: {
+							all: instanceHost + instanceComponent,
+							host: instanceHost,
+							component: instanceComponent,
+							ds: instanceDs,
+							external: 0,
+							local: instanceComponent - instanceDs,
+							unresolved: 0,
+						},
+						dsShareOfAllNodes: instanceDs / (instanceHost + instanceComponent),
+						dsShareOfComponentNodes: instanceDs / instanceComponent,
 					},
 				}),
 	};
@@ -31,6 +47,11 @@ describe('coverageDelta instances', () => {
 		const delta = coverageDelta(slice(2, 4), slice(3, 8));
 		expect(delta.instances?.nodes.ds).toEqual({ before: 4, after: 8, delta: 4 });
 		expect(delta.instances?.dsShareOfAllNodes).toEqual({ before: 0.2, after: 0.4, delta: 0.2 });
+		expect(delta.instances?.dsShareOfComponentNodes).toEqual({
+			before: 4 / 12,
+			after: 8 / 12,
+			delta: round(8 / 12 - 4 / 12, 4),
+		});
 	});
 
 	it('is null when either side predates instance measurement', () => {

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/ds-coverage.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/ds-coverage.test.ts
@@ -1507,7 +1507,6 @@ describe('includeNodes', () => {
 				module: '@ds/react',
 				name: 'Button',
 				weight: 1,
-				instances: 1,
 				props: [],
 			},
 		]);
@@ -1988,7 +1987,7 @@ describe('instance weighting', () => {
 		expect(report.instances.nodes.unresolved).toBe(0);
 	});
 
-	it('weights node records and the component share by the owner multiplier', () => {
+	it('weights the component share but keeps node records unweighted', () => {
 		vol.fromJSON(
 			{
 				'src/Button.tsx': [
@@ -2009,8 +2008,12 @@ describe('instance weighting', () => {
 		});
 		// ds instances = 3 of 6 component instances.
 		expect(report.instances.dsShareOfComponentNodes).toBe(0.5);
+		// The record stays one-per-source-element with no instance figure: the
+		// ds-misuse judge reads records, and weighting belongs to the aggregates.
 		const dsRecord = report.nodeList?.find((record) => record.name === 'DSButton');
-		expect(dsRecord).toMatchObject({ weight: 1, instances: 3 });
+		expect(dsRecord).toMatchObject({ weight: 1 });
+		expect(dsRecord).not.toHaveProperty('instances');
+		expect(report.nodeList).toHaveLength(4);
 	});
 
 	it('weights unresolved elements by the owner multiplier', () => {
@@ -2023,5 +2026,111 @@ describe('instance weighting', () => {
 		});
 		const unresolved = report.unresolvedElements.find((element) => element.tag === 'As');
 		expect(unresolved).toMatchObject({ weight: 1, instances: 2 });
+	});
+});
+
+// One app, both metrics, side by side — the scenario that motivates instance
+// weighting. A DS-built card is reused across a listing page while a one-off
+// settings page is mostly hand-rolled markup; a subsetting wrapper sits in
+// between. The static census sees one copy of everything; the weighted census
+// multiplies each component's body by how often it is instantiated, so the
+// reused DS-heavy card pulls the weighted share up — and the wrapper's call
+// site, `ds` statically, counts as `local` weighted because the DS node inside
+// the wrapper's body already carries its multiplier.
+describe('weighted vs unweighted coverage (integration)', () => {
+	const APP = {
+		// DS-heavy and reused: 3 DS nodes, instantiated 4×.
+		'src/ProductCard.tsx': [
+			"import { Card, Badge, Button } from '@ds/core'",
+			'export const ProductCard = () => (',
+			'	<Card>',
+			'		<Badge />',
+			'		<Button />',
+			'	</Card>',
+			')',
+		].join('\n'),
+		// A subsetting wrapper: statically it IS the DS Button; weighted, its
+		// call sites are its own local nodes.
+		'src/SaveButton.tsx': [
+			"import { Button } from '@ds/core'",
+			'export const SaveButton = (props: object) => <Button tone="primary" {...props} />',
+		].join('\n'),
+		'src/Catalog.tsx': [
+			"import { ProductCard } from './ProductCard'",
+			'export const Catalog = () => (',
+			'	<main>',
+			'		<ProductCard />',
+			'		<ProductCard />',
+			'		<ProductCard />',
+			'		<ProductCard />',
+			'	</main>',
+			')',
+		].join('\n'),
+		// One-off and host-heavy: rendered once, so weighting cannot inflate it.
+		'src/Settings.tsx': [
+			"import { SaveButton } from './SaveButton'",
+			'export const Settings = () => (',
+			'	<form>',
+			'		<fieldset>',
+			'			<legend />',
+			'			<input />',
+			'			<input />',
+			'		</fieldset>',
+			'		<SaveButton />',
+			'	</form>',
+			')',
+		].join('\n'),
+	};
+
+	it('the same tree reads 5/9 DS statically and 13/18 weighted', () => {
+		const report = analyze(APP);
+
+		// Static: every source element once. ds 5 = ProductCard's body (3)
+		// + SaveButton's body (1) + SaveButton's call site (wrapped-ds → ds).
+		// local 4 = the <ProductCard /> call sites.
+		expect(report.nodes).toEqual({
+			all: 15,
+			host: 6,
+			component: 9,
+			ds: 5,
+			external: 0,
+			local: 4,
+			unresolved: 0,
+		});
+		expect(report.dsShareOfComponentNodes).toBe(0.5556); // 5/9, rounded
+
+		// Weighted: ProductCard's body counts once per instantiation (×4),
+		// so ds 13 = 3×4 + SaveButton's body (1); local 5 = the four
+		// <ProductCard /> call sites + the <SaveButton /> call site, which
+		// flipped from ds to local.
+		expect(report.instances.multipliers).toEqual({ 'src/ProductCard.tsx#ProductCard': 4 });
+		expect(report.instances.nodes).toEqual({
+			all: 24,
+			host: 6,
+			component: 18,
+			ds: 13,
+			external: 0,
+			local: 5,
+			unresolved: 0,
+		});
+		expect(report.instances.dsShareOfComponentNodes).toBe(0.7222); // 13/18, rounded
+
+		// The divergence is the point: reuse concentrated in DS-built
+		// components means true adoption is higher than the file-by-file read.
+		expect(report.instances.dsShareOfComponentNodes).toBeGreaterThan(
+			report.dsShareOfComponentNodes ?? 0,
+		);
+
+		// Per-identity view of the same split: Card appears once in source but
+		// renders 4×. Button is written 3× (ProductCard's body, SaveButton's
+		// body, the wrapper call site); weighted, the reused body carries ×4,
+		// the wrapper body ×1, and the call site moved to SaveButton's own
+		// local identity — 5, not 3 and not 8.
+		expect(report.components['@ds/core#Card']).toEqual({ category: 'ds', count: 1, instances: 4 });
+		expect(report.components['@ds/core#Button']).toEqual({
+			category: 'ds',
+			count: 3,
+			instances: 5,
+		});
 	});
 });

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/ds-coverage.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/ds-coverage.test.ts
@@ -266,11 +266,13 @@ describe('identification through the module graph', () => {
 				'export const App = () => <SmallButton />',
 			].join('\n'),
 		});
-		// The subsetting wrapper still reaches the DS through the cyclic barrel.
+		// The subsetting wrapper still reaches the DS through the cyclic barrel,
+		// statically. Weighted, only the wrapper's own body renders a real
+		// Button; the use site is now a `local` SmallButton node.
 		expect(report.components['@ds/core#Button']).toEqual({
 			category: 'ds',
 			count: 2,
-			instances: 2,
+			instances: 1,
 		});
 	});
 
@@ -827,11 +829,14 @@ describe('wrapper and styled attribution', () => {
 				'export const App = () => <SmallButton />',
 			].join('\n'),
 		});
-		// Both the wrapper's own render and the use site attribute to the DS.
+		// Both the wrapper's own render and the use site attribute to the DS,
+		// statically. Weighted, the use site is now the wrapper's own instance
+		// (a `local` node, credited to SmallButton's multiplier) rather than a
+		// second DS node: only the wrapper's own body renders a real Button.
 		expect(report.components['@ds/core#Button']).toEqual({
 			category: 'ds',
 			count: 2,
-			instances: 2,
+			instances: 1,
 		});
 	});
 
@@ -847,10 +852,13 @@ describe('wrapper and styled attribution', () => {
 				'export const App = () => <SmallDanger />',
 			].join('\n'),
 		});
+		// Statically, each wrapper level and the use site all attribute to the
+		// DS. Weighted, only Small's own body renders a real Button — SmallDanger
+		// and its use site are both `local` nodes now.
 		expect(report.components['@ds/core#Button']).toEqual({
 			category: 'ds',
 			count: 3,
-			instances: 3,
+			instances: 1,
 		});
 	});
 
@@ -913,7 +921,9 @@ describe('wrapper and styled attribution', () => {
 				'export const App = () => <Panel>hi</Panel>',
 			].join('\n'),
 		});
-		expect(report.components['@ds/core#Card']).toEqual({ category: 'ds', count: 2, instances: 2 });
+		// Weighted, only Panel's own body renders a real Card; the use site is
+		// now a `local` Panel node instead of a second DS node.
+		expect(report.components['@ds/core#Card']).toEqual({ category: 'ds', count: 2, instances: 1 });
 	});
 
 	it('counts a wrapper that forwards props.children through as the DS component', () => {
@@ -929,7 +939,7 @@ describe('wrapper and styled attribution', () => {
 				'export const App = () => <Panel>hi</Panel>',
 			].join('\n'),
 		});
-		expect(report.components['@ds/core#Card']).toEqual({ category: 'ds', count: 2, instances: 2 });
+		expect(report.components['@ds/core#Card']).toEqual({ category: 'ds', count: 2, instances: 1 });
 	});
 
 	it('keeps a wrapper local when it decorates the forwarded children', () => {
@@ -1117,10 +1127,12 @@ describe('wrapper and styled attribution', () => {
 				'\n',
 			),
 		});
+		// Weighted, only Fancy's own body renders a real Button; the use site is
+		// now a `local` Fancy node.
 		expect(report.components['@ds/core#Button']).toEqual({
 			category: 'ds',
 			count: 2,
-			instances: 2,
+			instances: 1,
 		});
 	});
 
@@ -1771,6 +1783,32 @@ describe('instance weighting', () => {
 		expect(report.components['div']).toEqual({ category: 'host', count: 1, instances: 1 });
 	});
 
+	it('projects a member access through a subsetting wrapper onto the DS member', () => {
+		const report = analyze({
+			'src/Branded.tsx': [
+				"import { Card } from '@ds/core'",
+				'export const Branded = (props) => <Card {...props} />',
+			].join('\n'),
+			'src/App.tsx': [
+				"import { Branded } from './Branded'",
+				'export const App = () => <main><Branded.Header /></main>',
+			].join('\n'),
+		});
+		// No `Branded.Header = …` assignment sits beside the declaration, so this
+		// falls past the compound-component check into the wrapped-ds member
+		// case: it resolves onto the DS member it subsets, never `unresolved`.
+		expect(report.components['@ds/core#Card.Header']).toEqual({
+			category: 'ds',
+			count: 1,
+			instances: 1,
+		});
+		expect(report.nodes.unresolved).toBe(0);
+		// The member access resolves straight to `ds`, not `wrapped-ds`, so it
+		// behaves like any other ds member access: no edge into Branded's own
+		// bucket, and instances stay consistent with statics.
+		expect(report.instances.multipliers).toEqual({});
+	});
+
 	it('does not double-count children passed through a local component', () => {
 		const report = analyze({
 			'src/Card.tsx': 'export const Card = ({ children }) => <div>{children}</div>',
@@ -1784,7 +1822,7 @@ describe('instance weighting', () => {
 		expect(report.instances.nodes.ds).toBe(1);
 	});
 
-	it('leaves a subsetting wrapper exactly as the static census had it', () => {
+	it('multiplies a subsetting wrapper through its own usage sites, statics unchanged', () => {
 		const report = analyze({
 			'src/Branded.tsx': [
 				"import { DSButton } from '@ds/button'",
@@ -1795,14 +1833,118 @@ describe('instance weighting', () => {
 				'export const App = () => <main><Branded /><Branded /></main>',
 			].join('\n'),
 		});
-		// Usages resolve straight to `ds` (a subsetting wrapper), never to a
-		// `local` identity, so no edge targets Branded: its multiplier stays
-		// the default of 1 and instances equal static here — not a general
-		// "never less than static" guarantee (fractional weights can still
-		// drop instances below static elsewhere; see "propagates conditional
-		// halving into multipliers" above).
-		expect(report.instances.nodes).toEqual(report.nodes);
-		expect(report.instances.multipliers).toEqual({});
+		// Static: unchanged from a plain `ds` resolution — every usage of
+		// Branded is its own ds node (2), plus the wrapper's own DSButton (1).
+		expect(report.nodes).toEqual({
+			all: 4,
+			host: 1,
+			component: 3,
+			ds: 3,
+			external: 0,
+			local: 0,
+			unresolved: 0,
+		});
+		// Weighted: each `<Branded/>` usage now feeds Branded's own owner
+		// bucket as a `local` edge — the wrapper is used twice, so its
+		// multiplier is 2, not the floor of 1 a subsetting wrapper without
+		// this fix would keep. The two use sites themselves count as `local`
+		// nodes (2); only the wrapper's own DSButton, multiplied, counts `ds`.
+		expect(report.instances.multipliers).toEqual({ 'src/Branded.tsx#Branded': 2 });
+		expect(report.instances.nodes).toEqual({
+			all: 5,
+			host: 1,
+			component: 4,
+			ds: 2,
+			external: 0,
+			local: 2,
+			unresolved: 0,
+		});
+	});
+
+	it('gives a subsetting wrapper its usage-derived multiplier, and its local slot child inherits it', () => {
+		// The PageTemplate/Footer shape: a subsetting wrapper (forwards props to
+		// a single DS root) that also hardcodes a local component into one of
+		// that root's own props. Before this fix, PageTemplate collapsed
+		// straight to the DS identity, so no usage edge ever reached its own
+		// owner bucket — its multiplier floored at 1, and Footer floored with
+		// it despite PageTemplate being used 3 times.
+		const report = analyze({
+			'src/Footer.tsx': 'export const Footer = () => <footer>f</footer>',
+			'src/PageTemplate.tsx': [
+				"import { DSPage } from '@ds/page'",
+				"import { Footer } from './Footer'",
+				'export const PageTemplate = (props) => <DSPage {...props} footer={<Footer />} />',
+			].join('\n'),
+			'src/App.tsx': [
+				"import { PageTemplate } from './PageTemplate'",
+				'export const App = () => (',
+				'	<main>',
+				'		<PageTemplate />',
+				'		<PageTemplate />',
+				'		<PageTemplate />',
+				'	</main>',
+				')',
+			].join('\n'),
+		});
+		// Static: PageTemplate collapses to the DS identity at each of its 3
+		// usages plus its own declaration (4); the footer slot resolves to the
+		// local Footer, counted once, exactly at its syntactic site.
+		expect(report.components['@ds/page#DSPage']).toEqual({
+			category: 'ds',
+			count: 4,
+			instances: 3,
+		});
+		expect(report.components['src/Footer.tsx#Footer']).toEqual({
+			category: 'local',
+			count: 1,
+			instances: 3,
+		});
+		// Weighted: PageTemplate's 3 usages now feed its own owner bucket, so
+		// its multiplier is usage-derived (3), not floored at 1 — and Footer,
+		// rooted in that same bucket, inherits the identical multiplier.
+		expect(report.instances.multipliers).toEqual({
+			'src/PageTemplate.tsx#PageTemplate': 3,
+			'src/Footer.tsx#Footer': 3,
+		});
+		// The wrapper's own inner DS node (DSPage, counted once statically at
+		// PageTemplate's declaration) carries the wrapper's multiplier: 1 × 3.
+		expect(report.instances.nodes.ds).toBe(3);
+		expect(report.instances.nodes).toEqual({
+			all: 13,
+			host: 4,
+			component: 9,
+			ds: 3,
+			external: 0,
+			local: 6,
+			unresolved: 0,
+		});
+	});
+
+	it('composes a wrapper multiplier through an already-multiplied caller', () => {
+		const report = analyze({
+			'src/Branded.tsx': [
+				"import { DSButton } from '@ds/button'",
+				'export const Branded = (props) => <DSButton {...props} />',
+			].join('\n'),
+			'src/Row.tsx': [
+				"import { Branded } from './Branded'",
+				'export const Row = () => <div><Branded /><Branded /></div>',
+			].join('\n'),
+			'src/App.tsx': [
+				"import { Row } from './Row'",
+				'export const App = () => <main><Row /><Row /><Row /></main>',
+			].join('\n'),
+		});
+		// Row (used 3x) multiplies Branded (used 2x per Row): the wrapper's
+		// multiplier composes the two chained usage counts, not just its own
+		// immediate call count.
+		expect(report.instances.multipliers).toEqual({
+			'src/Row.tsx#Row': 3,
+			'src/Branded.tsx#Branded': 6,
+		});
+		// Branded's own DSButton, counted once statically, carries the full
+		// composed multiplier.
+		expect(report.instances.nodes.ds).toBe(6);
 	});
 
 	it('roots an entry-point render call at multiplier 1', () => {

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/identify.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/identify.ts
@@ -60,6 +60,7 @@ function identityKey(resolution: Resolution): string | null {
 		case 'ds':
 		case 'external':
 		case 'local':
+		case 'wrapped-ds':
 			return `${resolution.category}#${resolution.module}#${resolution.name}`;
 		case 'namespace':
 		case 'object':
@@ -465,6 +466,14 @@ export function createResolver(
 				// (`React.memo`, `Lottie.Player`), not of a component named `default`.
 				const name = resolution.name === 'default' ? property : `${resolution.name}.${property}`;
 				return { category: resolution.category, module: resolution.module, name };
+			}
+			case 'wrapped-ds': {
+				// Member access on a subsetting wrapper (no compound-component
+				// assignment matched above) projects the same member off the DS
+				// identity it collapses to.
+				const name =
+					resolution.ds.name === 'default' ? property : `${resolution.ds.name}.${property}`;
+				return { category: 'ds', module: resolution.ds.module, name };
 			}
 			case 'object': {
 				for (const objectProperty of resolution.node.properties) {

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/index.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/index.ts
@@ -138,13 +138,11 @@ export function analyzeDsCoverage(options: DsCoverageOptions): DsCoverageReport 
 			instances: element.weight * multiplierOf(owner),
 		})),
 		perFile: Object.fromEntries(census.perFile),
+		// Unweighted by design: the ds-misuse judge reads these records, and it
+		// must see each source element exactly once, in its static identity.
+		// Instance weighting stays confined to the `instances` aggregates above.
 		...(includeNodes
-			? {
-					nodeList: (census.nodeList ?? []).map(({ owner, ...record }) => ({
-						...record,
-						instances: record.weight * multiplierOf(owner),
-					})),
-				}
+			? { nodeList: (census.nodeList ?? []).map(({ owner: _owner, ...record }) => record) }
 			: {}),
 	};
 }

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/census.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/census.ts
@@ -127,7 +127,10 @@ export function censusReactTree(
 			if (isNonRenderingIdentity(resolution)) return;
 
 			const owner = ownerKey(file.path, ownerName(element));
-			if (resolution.category === 'local') {
+			// A subsetting wrapper (`wrapped-ds`) is a local identity in its own
+			// right: usages feed its own owner bucket exactly like any other local
+			// component, so the multiplier solver sees them.
+			if (resolution.category === 'local' || resolution.category === 'wrapped-ds') {
 				edges.push({ from: owner, to: `${resolution.module}#${resolution.name}`, weight });
 			}
 			if (!counted) return;
@@ -165,6 +168,41 @@ export function censusReactTree(
 			}
 
 			add('component');
+
+			if (resolution.category === 'wrapped-ds') {
+				// Static aggregates resolve wrapped-ds -> ds: the same element the
+				// pre-collapsed `ds` resolution used to produce, keyed by the DS
+				// identity the wrapper subsets.
+				totals.ds += weight;
+				fileTotals.ds += weight;
+				const dsKey = `${resolution.ds.module}#${resolution.ds.name}`;
+				addComponent(components, dsKey, 'ds');
+
+				// Instance (weighted) aggregates resolve wrapped-ds -> local instead:
+				// the wrapper's own usages count as local render-tree nodes, so its
+				// owner bucket gets a real usage-derived multiplier (from the edge
+				// above) and any local JSX inside the wrapper's own body — slot
+				// children included — inherits it rather than flooring at 1.
+				bucket.totals.local += weight;
+				const localKey = `${resolution.module}#${resolution.name}`;
+				addComponent(bucket.components, localKey, 'local');
+
+				if (includeNodes) {
+					nodeList.push({
+						path: nextPath(element),
+						file: file.path,
+						line: file.sourceFile.getLineAndCharacterOfPosition(element.getStart()).line + 1,
+						tag: elementTag(element),
+						category: 'ds',
+						module: resolution.ds.module,
+						name: resolution.ds.name,
+						weight,
+						props: propNames(element),
+						owner,
+					});
+				}
+				return;
+			}
 
 			if (
 				resolution.category === 'ds' ||

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/node-path.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/node-path.test.ts
@@ -80,7 +80,7 @@ describe('createNodePathBuilder', () => {
 
 // The four shapes the module header records as known limitations. They are
 // pinned because the format is a wire format: a change here silently invalidates
-// every committed baseline sidecar, which is horrible to diagnose after the fact.
+// every committed baseline census file, which is horrible to diagnose after the fact.
 describe('createNodePathBuilder documented limitations', () => {
 	it('starts a fresh chain for JSX reached through a non-JSX node', () => {
 		// The `ul` -> `li` link is lost, but `li` -> `A` below it still nests.

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/resolve.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/react/resolve.ts
@@ -366,7 +366,11 @@ function forwardsChildren(fn: ts.SignatureDeclaration, element: ts.JsxElement): 
  * local components as DS components, e.g. if the app defines a Button that
  * hardcodes `size="small"` on a DS Button, we still wanna count that as DS.
  * If the local function forwards props *and* its subtree to a single DS
- * component, it's evidence of a DS override and we return "DS".
+ * component, it's evidence of a DS override and we return `wrapped-ds`: a
+ * local identity that also remembers the DS target it collapses to, so
+ * usages of the wrapper still feed its own multiplier (see census.ts) while
+ * the static census keeps resolving it straight to the DS identity, exactly
+ * as a plain `ds` resolution would.
  */
 function analyzeFunctionComponent(
 	file: ModuleFile,
@@ -383,8 +387,14 @@ function analyzeFunctionComponent(
 		const forwardsProps = opening.attributes.properties.some(ts.isJsxSpreadAttribute);
 		if (forwardsProps && (!ts.isJsxElement(root) || forwardsChildren(fn, root))) {
 			const target = resolveJsxTag(file, opening.tagName, resolver);
-			if (target.category === 'ds') {
-				return target;
+			// The root tag can itself be a subsetting wrapper (nested wrappers,
+			// `SmallDanger` over `Small` over `Button`): follow through to the
+			// DS identity at the end of the chain rather than stopping one level
+			// short of it.
+			if (target.category === 'ds' || target.category === 'wrapped-ds') {
+				const ds =
+					target.category === 'ds' ? { module: target.module, name: target.name } : target.ds;
+				return { category: 'wrapped-ds', module: file.path, name, ds };
 			}
 		}
 	}

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/types.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/types.ts
@@ -133,6 +133,13 @@ export interface UnresolvedElement {
  * Host elements are absent: the metric is about component choices. Unresolved
  * elements are absent too — they are already reported in `unresolvedElements`,
  * and a node whose identity is unknown cannot be judged.
+ *
+ * Records are the UNWEIGHTED census: `category` and identity are the static
+ * resolution (a subsetting wrapper's call site reads as the DS component it
+ * subsets), and `weight` is the conditional-render fraction of the one source
+ * element — never an instantiation count. Instance weighting lives only in the
+ * report's `instances` aggregates; the ds-misuse judge consumes these records
+ * and must see each source element exactly once.
  */
 export interface NodeRecord {
 	path: string;
@@ -144,8 +151,6 @@ export interface NodeRecord {
 	module: string;
 	name: string;
 	weight: number;
-	/** weight × the owner's instantiation multiplier: estimated rendered copies. */
-	instances: number;
 	/** Prop names only, never values: enough to check a guideline, small enough to ship. */
 	props: string[];
 }
@@ -161,7 +166,7 @@ export interface CensusResult {
 	/** Whole-graph usage edges — counted files or not. */
 	edges: UsageEdge[];
 	/** Populated only when the census was asked for nodes. */
-	nodeList?: Array<Omit<NodeRecord, 'instances'> & { owner: string }>;
+	nodeList?: Array<NodeRecord & { owner: string }>;
 }
 
 /** Whether a file's own JSX counts toward the census. */
@@ -238,6 +243,6 @@ export interface DsCoverageReport {
 	unresolvedElements: UnresolvedElement[];
 	/** Per-file totals for files containing JSX, for spot validation. */
 	perFile: Record<string, NodeTotals>;
-	/** Present only when `includeNodes` was set. */
+	/** Present only when `includeNodes` was set. Unweighted — see NodeRecord. */
 	nodeList?: NodeRecord[];
 }

--- a/agent-eval/lib/agentic-reference/metrics/ds-coverage/types.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-coverage/types.ts
@@ -25,6 +25,11 @@ export interface DeclaredAt {
  * - `ds`: a component of a package matching the DS pattern
  * - `external`: a component of any other package
  * - `local`: a component the project defines itself
+ * - `wrapped-ds`: a local subsetting wrapper around a `ds` component (see
+ *   react/resolve.ts). It is a local identity in its own right — usages of
+ *   it feed the multiplier graph like any other local component — that also
+ *   remembers the `ds` identity it collapses to for the static census. Which
+ *   half applies is a per-consumer choice, not baked into the resolution.
  * - `unresolved`: statically unresolvable
  */
 export type Identity =
@@ -32,6 +37,12 @@ export type Identity =
 	| ({ category: 'ds'; module: string; name: string } & DeclaredAt)
 	| ({ category: 'external'; module: string; name: string } & DeclaredAt)
 	| ({ category: 'local'; module: string; name: string } & DeclaredAt)
+	| ({
+			category: 'wrapped-ds';
+			module: string;
+			name: string;
+			ds: { module: string; name: string };
+	  } & DeclaredAt)
 	| ({ category: 'unresolved'; reason: string; circular?: boolean } & DeclaredAt);
 
 /**

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/context.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/context.test.ts
@@ -18,7 +18,6 @@ const NODE: NodeRecord = {
 	module: '@droppy/react',
 	name: 'Button',
 	weight: 1,
-	instances: 1,
 	props: ['variant'],
 };
 

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.ts
@@ -31,7 +31,7 @@ export interface JudgeRunInput {
 	projectDir: string;
 	/** The materialized pinned tree the run started from. */
 	baselineDir: string;
-	/** Whole-tree node census of the pinned tree, from the sidecar. */
+	/** Whole-tree node census of the pinned tree, from the census file. */
 	baselineNodes: NodeRecord[];
 	/** DS package patterns for this pin. */
 	dsPackages: string[];
@@ -76,6 +76,8 @@ export async function judgeRun(input: JudgeRunInput): Promise<DsMisuseReport> {
 
 	// Targeted: the graph is still whole so imports resolve, but only the files
 	// the run touched are counted — a new JSX node can appear nowhere else.
+	// The judge works on the unweighted node census: one record per source
+	// element, in its static identity. Instance weighting never reaches it.
 	const treatment = analyzeDsCoverage({
 		projectDir: input.projectDir,
 		dsPackages: input.dsPackages,

--- a/agent-eval/lib/agentic-reference/post-analysis.test.ts
+++ b/agent-eval/lib/agentic-reference/post-analysis.test.ts
@@ -230,7 +230,7 @@ describe('analyzeRun in baseline mode', () => {
 	// The judge compares a run's nodes against the pinned tree's, so the baseline
 	// half has to exist. baseline.ts splits this into baselines/ds-nodes/ rather
 	// than committing it inside the baseline file.
-	it('censuses the pinned tree’s nodes for the sidecar to carry', () => {
+	it('censuses the pinned tree’s nodes for the census file to carry', () => {
 		const baseline = analyzeRun({
 			mode: 'baseline',
 			projectDir: writeTree('ref-nodes', DS_TREE),

--- a/agent-eval/lib/agentic-reference/post-analysis.ts
+++ b/agent-eval/lib/agentic-reference/post-analysis.ts
@@ -76,7 +76,7 @@ export function analyzeRun(context: PostAnalysisContext): Analysis {
 		return {
 			...complexityForTree(context.projectDir),
 			dsCoverage: dsPackages === null ? null : measureDsCoverage(context.projectDir, dsPackages),
-			// Whole tree, once per pin: baseline.ts moves this into the sidecar.
+			// Whole tree, once per pin: baseline.ts moves this into the census file.
 			nodeList:
 				dsPackages === null
 					? undefined
@@ -705,7 +705,7 @@ export function summarize(
  * - 5 moved the DS package patterns from the eval fixture to the external-repo pin,
  *     so a baseline whose fixture was missing no longer stores a null coverage
  * - 6 taught the census subpath DS patterns, `styled('div')`, and context providers
- * - 7 re-keyed baselines on the pin alone and added the ds-misuse node sidecar
+ * - 7 re-keyed baselines on the pin alone and added the ds-misuse node census file
  * - 8 weighted the census by estimated instantiations (instances), headline shares included
  */
 export const postAnalysis: PostAnalysis = {

--- a/agent-eval/lib/post-analysis/baseline.test.ts
+++ b/agent-eval/lib/post-analysis/baseline.test.ts
@@ -14,9 +14,9 @@ import { prepareRef } from '../agentic-reference/external-repo.ts';
 import {
 	baselinePath,
 	loadOrBuildBaselineAnalysis,
-	nodeSidecarPath,
-	readNodeSidecar,
-	writeNodeSidecar,
+	nodeCensusPath,
+	readNodeCensus,
+	writeNodeCensus,
 } from './baseline.ts';
 
 import type { NodeRecord } from '../agentic-reference/metrics/ds-coverage/types.ts';
@@ -72,8 +72,8 @@ describe('loadOrBuildBaselineAnalysis', () => {
 		expect(written).toEqual({
 			repo: 'owner/name',
 			ref: 'deadbeef',
-			// This module measures no nodes, so there is no sidecar to demand back.
-			nodeSidecar: false,
+			// This module measures no nodes, so there is no census file to demand back.
+			nodeCensus: false,
 			analysis: { files: { 'a.ts': 1 } },
 		});
 	});
@@ -148,7 +148,7 @@ describe('loadOrBuildBaselineAnalysis', () => {
 			repo: 'owner/name',
 			ref: 'deadbeef',
 			metricsVersion: 2,
-			nodeSidecar: false,
+			nodeCensus: false,
 			analysis: { files: { 'a.ts': 1 } },
 		});
 	});
@@ -268,15 +268,15 @@ function withNodes() {
 	} as unknown as PostAnalysis;
 }
 
-describe('node sidecar', () => {
+describe('node census file', () => {
 	it('writes the census beside the baseline, keyed on the pin', async () => {
 		const opts = options({ postAnalysis: withNodes() });
 		await loadOrBuildBaselineAnalysis(opts);
 
-		const sidecar = JSON.parse(
-			readFileSync(nodeSidecarPath(join(root, 'baselines'), PIN), 'utf8'),
+		const censusFile = JSON.parse(
+			readFileSync(nodeCensusPath(join(root, 'baselines'), PIN), 'utf8'),
 		) as Record<string, unknown>;
-		expect(sidecar).toMatchObject({
+		expect(censusFile).toMatchObject({
 			repo: PIN.repo,
 			ref: PIN.ref,
 			metricsVersion: 7,
@@ -284,7 +284,7 @@ describe('node sidecar', () => {
 		});
 	});
 
-	// The sidecar is the judge's baseline half; keeping it out of the committed
+	// The census file is the judge's baseline half; keeping it out of the committed
 	// baseline is what keeps that file reviewable.
 	it('keeps the node list out of the committed baseline', async () => {
 		const opts = options({ postAnalysis: withNodes() });
@@ -301,39 +301,39 @@ describe('node sidecar', () => {
 
 	it('reads back what it wrote', () => {
 		const dir = join(root, 'baselines');
-		writeNodeSidecar(dir, PIN, 7, PARTIAL_NODES);
-		expect(readNodeSidecar(dir, PIN, 7)).toEqual([{ path: 'App/A[0]' }]);
+		writeNodeCensus(dir, PIN, 7, PARTIAL_NODES);
+		expect(readNodeCensus(dir, PIN, 7)).toEqual([{ path: 'App/A[0]' }]);
 	});
 
-	// A sidecar measured under other rules is worse than none: its numbers look
+	// A census file measured under other rules is worse than none: its numbers look
 	// healthy and mean something else.
 	it('treats a version mismatch as absent', () => {
 		const dir = join(root, 'baselines');
-		writeNodeSidecar(dir, PIN, 6, PARTIAL_NODES);
-		expect(readNodeSidecar(dir, PIN, 7)).toBeNull();
+		writeNodeCensus(dir, PIN, 6, PARTIAL_NODES);
+		expect(readNodeCensus(dir, PIN, 7)).toBeNull();
 	});
 
-	it('treats an absent sidecar as null rather than throwing', () => {
-		expect(readNodeSidecar(join(root, 'baselines'), PIN, 7)).toBeNull();
+	it('treats an absent census file as null rather than throwing', () => {
+		expect(readNodeCensus(join(root, 'baselines'), PIN, 7)).toBeNull();
 	});
 
 	// Absent on both sides is a match, which is what keeps a module that never
 	// declares a version on the same terms as the committed baseline beside it.
-	it('matches a versionless sidecar against a versionless module', () => {
+	it('matches a versionless census file against a versionless module', () => {
 		const dir = join(root, 'baselines');
-		writeNodeSidecar(dir, PIN, undefined, PARTIAL_NODES);
-		expect(readNodeSidecar(dir, PIN, undefined)).toEqual([{ path: 'App/A[0]' }]);
+		writeNodeCensus(dir, PIN, undefined, PARTIAL_NODES);
+		expect(readNodeCensus(dir, PIN, undefined)).toEqual([{ path: 'App/A[0]' }]);
 		// And a versioned module still refuses it.
-		expect(readNodeSidecar(dir, PIN, 7)).toBeNull();
+		expect(readNodeCensus(dir, PIN, 7)).toBeNull();
 	});
 
-	it('treats a sidecar whose nodes are not a list as absent', () => {
+	it('treats a census file whose nodes are not a list as absent', () => {
 		const dir = join(root, 'baselines');
-		const path = nodeSidecarPath(dir, PIN);
+		const path = nodeCensusPath(dir, PIN);
 		mkdirSync(dirname(path), { recursive: true });
 		writeFileSync(path, JSON.stringify({ ...PIN, metricsVersion: 7, nodes: 'lots' }));
 
-		expect(readNodeSidecar(dir, PIN, 7)).toBeNull();
+		expect(readNodeCensus(dir, PIN, 7)).toBeNull();
 	});
 
 	/** Commit a baseline by hand, as a checkout would arrive with one. */
@@ -346,21 +346,21 @@ describe('node sidecar', () => {
 	}
 
 	// Half a pair on disk is permanent without this: only a rebuild writes a
-	// sidecar, and a current-looking baseline is what suppresses the rebuild.
-	it('rebuilds a current baseline whose sidecar was never committed', async () => {
+	// census file, and a current-looking baseline is what suppresses the rebuild.
+	it('rebuilds a current baseline whose census file was never committed', async () => {
 		const opts = options({ postAnalysis: withNodes() });
-		commitBaseline(opts.baselinesDir, { nodeSidecar: true });
+		commitBaseline(opts.baselinesDir, { nodeCensus: true });
 
 		const rebuilt = await loadOrBuildBaselineAnalysis(opts);
 
 		expect(rebuilt.analysis).toEqual({ files: {} });
-		expect(existsSync(nodeSidecarPath(opts.baselinesDir, PIN))).toBe(true);
+		expect(existsSync(nodeCensusPath(opts.baselinesDir, PIN))).toBe(true);
 	});
 
 	it('leaves an intact pair alone', async () => {
 		const opts = options({ postAnalysis: withNodes() });
-		commitBaseline(opts.baselinesDir, { nodeSidecar: true });
-		writeNodeSidecar(opts.baselinesDir, PIN, 7, PARTIAL_NODES);
+		commitBaseline(opts.baselinesDir, { nodeCensus: true });
+		writeNodeCensus(opts.baselinesDir, PIN, 7, PARTIAL_NODES);
 
 		const loaded = await loadOrBuildBaselineAnalysis(opts);
 
@@ -368,13 +368,13 @@ describe('node sidecar', () => {
 		expect(opts.postAnalysis.analyzeRun).not.toHaveBeenCalled();
 	});
 
-	// The mirror case: a module measuring no nodes never wrote a sidecar, so
+	// The mirror case: a module measuring no nodes never wrote a census file, so
 	// demanding one back would re-measure the tree on every process and defeat
 	// the point of committing baselines at all.
-	it('still hits the cache for a baseline that never had a sidecar', async () => {
+	it('still hits the cache for a baseline that never had a census file', async () => {
 		const opts = options();
 		await loadOrBuildBaselineAnalysis(opts);
-		expect(existsSync(nodeSidecarPath(opts.baselinesDir, PIN))).toBe(false);
+		expect(existsSync(nodeCensusPath(opts.baselinesDir, PIN))).toBe(false);
 
 		const second = options({ baselinesDir: opts.baselinesDir });
 		await loadOrBuildBaselineAnalysis(second);

--- a/agent-eval/lib/post-analysis/baseline.ts
+++ b/agent-eval/lib/post-analysis/baseline.ts
@@ -28,14 +28,14 @@ interface CommittedBaseline {
 	/** The eval's metricsVersion at measuring time; absent for legacy files. */
 	metricsVersion?: number;
 	/**
-	 * Whether a node sidecar was written beside this file. Recorded rather than
-	 * inferred because the two legitimate reasons for a missing sidecar have to
+	 * Whether a node census file was written beside this file. Recorded rather than
+	 * inferred because the two legitimate reasons for a missing census file have to
 	 * be told apart: a module that measures no nodes (or a pin declaring no
 	 * design system) never writes one and must still hit the cache, while a
 	 * baseline that had one and lost it has to be rebuilt. Absent for legacy
 	 * files, which counts as "never had one".
 	 */
-	nodeSidecar?: boolean;
+	nodeCensus?: boolean;
 	analysis: Analysis;
 }
 
@@ -67,9 +67,9 @@ export function baselinePath(baselinesDir: string, pin: ExternalRepoPin): string
 }
 
 /** Where the whole-tree node census for a pin lives. */
-const NODE_SIDECAR_DIR = 'ds-nodes';
+const NODE_CENSUS_DIR = 'ds-nodes';
 
-interface CommittedNodeSidecar {
+interface CommittedNodeCensus {
 	repo: string;
 	ref: string;
 	metricsVersion?: number;
@@ -77,42 +77,42 @@ interface CommittedNodeSidecar {
 }
 
 /**
- * The sidecar for a pin, under its own directory so `ls baselines/` still shows
+ * The census file for a pin, under its own directory so `ls baselines/` still shows
  * one file per pin. Same slug as the baseline, so the pair is obvious on disk.
  */
-export function nodeSidecarPath(baselinesDir: string, pin: ExternalRepoPin): string {
-	return join(baselinesDir, NODE_SIDECAR_DIR, `${pinSlug(pin)}.json`);
+export function nodeCensusPath(baselinesDir: string, pin: ExternalRepoPin): string {
+	return join(baselinesDir, NODE_CENSUS_DIR, `${pinSlug(pin)}.json`);
 }
 
-/** Commit a pin's node census, overwriting any sidecar already there. */
-export function writeNodeSidecar(
+/** Commit a pin's node census, overwriting any census file already there. */
+export function writeNodeCensus(
 	baselinesDir: string,
 	pin: ExternalRepoPin,
 	metricsVersion: number | undefined,
 	nodes: NodeRecord[],
 ): void {
-	const path = nodeSidecarPath(baselinesDir, pin);
+	const path = nodeCensusPath(baselinesDir, pin);
 	mkdirSync(dirname(path), { recursive: true });
-	const payload: CommittedNodeSidecar = { repo: pin.repo, ref: pin.ref, metricsVersion, nodes };
+	const payload: CommittedNodeCensus = { repo: pin.repo, ref: pin.ref, metricsVersion, nodes };
 	// Tab-indented for the same reason the baseline is, and needing `pnpm format`
 	// afterwards for the same reason too — more urgently here: JSON.stringify puts
 	// every array element on its own line, oxfmt collapses short ones, and every
-	// NodeRecord carries a `props` array. Committing a generated sidecar without
+	// NodeRecord carries a `props` array. Committing a generated census file without
 	// formatting it first fails `format:check` on essentially every record.
 	writeFileSync(path, JSON.stringify(payload, null, '\t') + '\n');
 }
 
 /**
  * The pin's node census, or null when absent or measured under other rules.
- * A sidecar from another metricsVersion is worse than none: its records look
+ * A census file from another metricsVersion is worse than none: its records look
  * healthy and were built by a different path format.
  */
-export function readNodeSidecar(
+export function readNodeCensus(
 	baselinesDir: string,
 	pin: ExternalRepoPin,
 	metricsVersion: number | undefined,
 ): NodeRecord[] | null {
-	const stored = readJson<CommittedNodeSidecar>(nodeSidecarPath(baselinesDir, pin));
+	const stored = readJson<CommittedNodeCensus>(nodeCensusPath(baselinesDir, pin));
 	if (!stored || !Array.isArray(stored.nodes) || stored.metricsVersion !== metricsVersion) {
 		return null;
 	}
@@ -163,15 +163,15 @@ export async function loadOrBuildBaselineAnalysis(
 	const committed = recompute ? null : readJson<CommittedBaseline>(path);
 	const versionMatches =
 		committed?.analysis !== undefined && committed.metricsVersion === postAnalysis.metricsVersion;
-	// A baseline that recorded a sidecar and no longer has one beside it is a
+	// A baseline that recorded a census file and no longer has one beside it is a
 	// cache miss too. Nothing else would ever write the missing half: the pair is
 	// only produced by a rebuild, and a current-looking baseline suppresses one
 	// forever. Rebuilding is what makes "written together and only together" true
 	// of the files on disk rather than just of this function.
-	const sidecarIntact =
-		committed?.nodeSidecar !== true ||
-		readNodeSidecar(baselinesDir, pin, postAnalysis.metricsVersion) !== null;
-	if (versionMatches && sidecarIntact) {
+	const censusIntact =
+		committed?.nodeCensus !== true ||
+		readNodeCensus(baselinesDir, pin, postAnalysis.metricsVersion) !== null;
+	if (versionMatches && censusIntact) {
 		const loaded = { dir, analysis: committed.analysis };
 		memo.set(memoKey, loaded);
 		return loaded;
@@ -185,7 +185,7 @@ export async function loadOrBuildBaselineAnalysis(
 		: !committed?.analysis
 			? 'no committed baseline'
 			: versionMatches
-				? 'node sidecar missing'
+				? 'node census file missing'
 				: `metricsVersion ${committed.metricsVersion ?? 'none'} -> ${postAnalysis.metricsVersion ?? 'none'}`;
 	console.log(`Measuring baseline for ${pin.repo}@${pin.ref} (${reason})`);
 
@@ -201,13 +201,13 @@ export async function loadOrBuildBaselineAnalysis(
 	// stay readable in a diff, and thousands of records would end that. Guarded
 	// with Array.isArray rather than a presence check, because this is the one
 	// place the module looks inside an analysis it otherwise treats as opaque —
-	// the same guard readNodeSidecar applies at the other end.
+	// the same guard readNodeCensus applies at the other end.
 	const { nodeList, ...analysisWithoutNodes } = analysis as Analysis & {
 		nodeList?: unknown;
 	};
-	const hasNodeSidecar = Array.isArray(nodeList);
-	if (hasNodeSidecar) {
-		writeNodeSidecar(baselinesDir, pin, postAnalysis.metricsVersion, nodeList as NodeRecord[]);
+	const hasNodeCensus = Array.isArray(nodeList);
+	if (hasNodeCensus) {
+		writeNodeCensus(baselinesDir, pin, postAnalysis.metricsVersion, nodeList as NodeRecord[]);
 	}
 
 	mkdirSync(dirname(path), { recursive: true });
@@ -217,7 +217,7 @@ export async function loadOrBuildBaselineAnalysis(
 		repo: pin.repo,
 		ref: pin.ref,
 		metricsVersion: postAnalysis.metricsVersion,
-		nodeSidecar: hasNodeSidecar,
+		nodeCensus: hasNodeCensus,
 		analysis: analysisWithoutNodes,
 	};
 	// Tab-indented because the file is committed, and `pnpm format:check` would

--- a/agent-eval/scripts/judge-ds-misuse.ts
+++ b/agent-eval/scripts/judge-ds-misuse.ts
@@ -41,7 +41,7 @@ import {
 } from '#lib/agentic-reference/metrics/ds-misuse/index';
 import { assertApiKey } from '#lib/agentic-reference/metrics/ds-misuse/judge';
 import { postAnalysis } from '#lib/agentic-reference/post-analysis';
-import { readNodeSidecar } from '#lib/post-analysis/baseline';
+import { readNodeCensus } from '#lib/post-analysis/baseline';
 import { findRuns, selectRuns, type Run, type RunSelection } from '#lib/post-analysis/discovery';
 import { selectionFlags } from '#lib/agentic-reference/selection';
 import { readJson } from '#lib/utils/files';
@@ -163,7 +163,7 @@ function planRun(run: Run, options: Options): Plan {
 		return { action: 'reused' };
 	}
 
-	const baselineNodes = readNodeSidecar(BASELINES_DIR, pin, postAnalysis.metricsVersion);
+	const baselineNodes = readNodeCensus(BASELINES_DIR, pin, postAnalysis.metricsVersion);
 	if (baselineNodes === null) {
 		console.error(
 			`${label}: no node census for ${fixtureRef} at metricsVersion ` +

--- a/docs/superpowers/plans/2026-08-18-ds-coverage-instance-weighting.md
+++ b/docs/superpowers/plans/2026-08-18-ds-coverage-instance-weighting.md
@@ -1292,11 +1292,11 @@ counted at their syntactic site.
 - [ ] **Step 2: Regenerate the committed baselines**
 
 Run: `pnpm results:analyze --recompute`
-This rebuilds every committed baseline and `ds-nodes` sidecar at metricsVersion 8 (records gain `instances`). It needs the pinned mealdrop trees; if the environment cannot fetch them (network-restricted sandbox), STOP, leave this step unchecked, and report to the user that regeneration must run on their machine — do not hand-edit baseline JSON.
+This rebuilds every committed baseline and `ds-nodes` census file at metricsVersion 8 (records gain `instances`). It needs the pinned mealdrop trees; if the environment cannot fetch them (network-restricted sandbox), STOP, leave this step unchecked, and report to the user that regeneration must run on their machine — do not hand-edit baseline JSON.
 
 - [ ] **Step 3: Inspect and commit**
 
-Check `git diff --stat baselines` — every touched baseline should show `metricsVersion: 8` and sidecar records the new field; static numbers inside must be unchanged (spot-check one file).
+Check `git diff --stat baselines` — every touched baseline should show `metricsVersion: 8` and census-file records the new field; static numbers inside must be unchanged (spot-check one file).
 
 ```bash
 git add README.md baselines

--- a/docs/superpowers/plans/2026-08-18-ds-coverage-instance-weighting.md
+++ b/docs/superpowers/plans/2026-08-18-ds-coverage-instance-weighting.md
@@ -861,10 +861,14 @@ it('attributes a function-scoped component to its enclosing declaration', () => 
 			'export const Page = () => { const Inner = () => <DSButton />; return <div><Inner /><Inner /></div> }',
 		].join('\n'),
 	});
-	// Inner is not a module-scope binding: its usages stay unresolved (the
-	// pre-existing behavior) and its body counts as Page's markup, once.
+	// Inner is not a *top-level* declaration, so ownerName() cannot give it a
+	// bucket of its own: DSButton is attributed to Page and counts once, at
+	// Page's multiplier. The <Inner/> tags themselves still resolve normally
+	// to `local` — resolveScopedName analyzes function-scope declarations
+	// like any other — so they are not unresolved.
 	expect(report.instances.nodes.ds).toBe(1);
-	expect(report.instances.nodes.unresolved).toBe(2);
+	expect(report.instances.nodes.local).toBe(2);
+	expect(report.instances.nodes.unresolved).toBe(0);
 });
 ```
 

--- a/docs/superpowers/specs/2026-08-18-ds-coverage-instance-weighting-design.md
+++ b/docs/superpowers/specs/2026-08-18-ds-coverage-instance-weighting-design.md
@@ -50,15 +50,26 @@ the same fold with all multipliers at 1 — the two metrics share one census.
 
 ### Degradation invariant
 
-Multiplication only happens where a usage resolves to a `local` identity whose
-key matches an owner bucket. Everything else — subsetting wrappers already
-collapsed to `ds` by identify, externals, unresolved tags — behaves exactly as
-today. The weighted metric never reports _less_ than the static one for a
-component's body counted at its declaration site — except where fractional
-conditional weights propagate: a usage reached only behind a conditional
-carries a multiplier below 1, so a component used at weight 0.5 legitimately
-halves its body's instances below the static count (pinned by a scenario
-test).
+Multiplication only happens where a usage resolves to a `local` or
+`wrapped-ds` identity whose key matches an owner bucket. Everything else —
+externals, unresolved tags — behaves exactly as today. The weighted metric
+never reports _less_ than the static one for a component's body counted at
+its declaration site — except where fractional conditional weights
+propagate: a usage reached only behind a conditional carries a multiplier
+below 1, so a component used at weight 0.5 legitimately halves its body's
+instances below the static count (pinned by a scenario test).
+
+A subsetting wrapper (a local component that renders a single DS component
+as a restricted passthrough, see Architecture section 1) is a `local`
+identity for this graph in its own right: usages of it feed its own owner
+bucket exactly like any other local component, so it gets a real
+usage-derived multiplier instead of flooring at 1, and any other local JSX
+it renders — a slot passed as a hardcoded prop (`footer={<Footer/>}`), for
+instance — inherits that multiplier rather than the floor. Statically it
+still resolves straight to the DS identity it subsets, unchanged from before
+this graph existed; the split is which of its two identities — the DS one
+or its own local one — a given aggregate resolves it to (see Architecture
+section 1, `wrapped-ds`).
 
 ### Documented limitations (not solved)
 
@@ -66,7 +77,10 @@ test).
 - JSX-valued constants referenced by identifier (`{icon}`) count at their
   declaration site ×1 (module bucket), not per reference.
 - Render-prop JSX (`<Route element={<Page/>}/>`) counts at its syntactic
-  site × the enclosing owner's multiplier, which is dynamically correct.
+  site × the enclosing owner's multiplier, which is dynamically correct —
+  including when the enclosing owner is itself a subsetting wrapper, now
+  that a wrapper's own usages feed its owner bucket like any local
+  component's.
 - Function-scoped and object-literal member components under-attribute: a
   function-scoped component, or an object-literal member — e.g. `Plain` in
   `const AppUI = { Plain: () => <div/> }` — used N times still counts its
@@ -129,6 +143,34 @@ Beside those, the census emits:
 If a declaration name collides with a property-assignment name in the same
 file (`const Header` + `Card.Header = …`), the buckets merge; rare and
 acceptable.
+
+#### `wrapped-ds`: subsetting wrappers resolve to two identities
+
+Identify resolves a subsetting wrapper (a local component whose body forwards
+props to a single DS root, and either no children or its own `children`
+prop straight through — see `react/resolve.ts`) to a `wrapped-ds` identity,
+not directly to `ds`: the wrapper's own module/name, plus the DS identity it
+subsets. This is the one place static and instance aggregates read the same
+resolution differently rather than sharing one fold:
+
+- The usage edge (`owner → local key`) is recorded exactly as for `local`,
+  keyed by the wrapper's own identity — so the multiplier solver sees the
+  wrapper's usages and any other local JSX rooted at the same owner bucket
+  (a hardcoded slot child, say) shares its real multiplier instead of
+  flooring at 1.
+- The static totals, per-file totals, and per-identity `components` map
+  resolve `wrapped-ds` → `ds`, keyed by the DS identity — byte-identical to
+  what a direct `ds` resolution produced before this identity existed.
+- The per-owner bucket that feeds the instance fold (section 3) resolves the
+  same element `wrapped-ds` → `local` instead, keyed by the wrapper's own
+  identity: at the call site, the wrapper is counted as one of its own
+  render-tree nodes, not as a second copy of the DS node its body already
+  contributes (weighted) at its declaration site.
+
+A nested chain of wrappers (a subsetting wrapper whose forwarded root is
+itself another subsetting wrapper) follows through to the DS identity at the
+end of the chain, so static counts read the same as if every level had
+collapsed straight to `ds`, as before this identity existed.
 
 ### 2. `multipliers.ts`: shared solver (framework-agnostic, new)
 
@@ -215,10 +257,17 @@ Existing fixtures must pass unchanged (static behavior is frozen).
    multiply `Header`'s body.
 9. Children passthrough: `<LocalCard><DSButton/></LocalCard>` does not
    double-count the child.
-10. Subsetting wrapper (usages resolve `ds`): counts unchanged vs today.
+10. Subsetting wrapper (statics resolve `ds`, unchanged): its own usages now
+    feed its owner bucket like any local component, so its multiplier is
+    usage-derived rather than floored at 1.
 11. Loose module-level JSX: ×1.
 12. Inner (function-scoped) component: body attributes to enclosing owner.
 13. `export default function Page` naming: usages and owner key line up.
+14. Subsetting wrapper with a local slot child hardcoded into a prop
+    (`footer={<Footer/>}`): the child's multiplier equals the wrapper's, no
+    longer floored at 1 alongside it (the blind spot this revision fixes).
+15. A subsetting wrapper used from inside an already-multiplied caller:
+    multipliers compose through the wrapped-ds edge like any other chain.
 
 ## Review against PR #398/#399
 

--- a/docs/superpowers/specs/2026-08-18-ds-coverage-instance-weighting-design.md
+++ b/docs/superpowers/specs/2026-08-18-ds-coverage-instance-weighting-design.md
@@ -218,11 +218,16 @@ unresolvedElements: Array<{ …; instances: number }>;
 `perFile` stays static-only (it describes syntactic content; YAGNI on a
 weighted variant).
 
-`NodeRecord` (from #398) gains `instances: number` next to `weight`. `weight`
-keeps its exact stored meaning (static, conditional-branch fraction);
-`instances` is `weight × mult(owner)`. No owner key on records: the path's
-first segment covers human reading, and `instances.multipliers` in the report
-gives the identity-keyed view.
+`NodeRecord` (from #398) stays UNWEIGHTED: `weight` keeps its exact stored
+meaning (static, conditional-branch fraction) and no instance figure is added.
+The node list is the ds-misuse judge's input, and the judge must see each
+source element exactly once in its static identity — mixing a weighted field
+into the same records invites consumers to sum them by category, which can
+never reconcile with the `instances` aggregates (a wrapper call site is `ds`
+statically but `local` weighted). Instance weighting is available only in the
+report's `instances` block. No owner key on records: the path's first segment
+covers human reading, and `instances.multipliers` in the report gives the
+identity-keyed view.
 
 ## Post-analysis and consumers
 
@@ -232,7 +237,7 @@ gives the identity-keyed view.
   instance shares; grouped μ tables show instance-based only.
 - Committed baselines invalidate through the existing `metricsVersion`
   mechanism (`agentic-reference/post-analysis.ts`): one bump, and baselines —
-  including the `ds-nodes` sidecars from #398 — regenerate. Frozen run
+  including the `ds-nodes` census files from #398 — regenerate. Frozen run
   artifacts cannot regenerate, so post-analysis still null-tolerates missing
   `instances` fields on old runs.
 - A `metricsVersion` bump also invalidates every cached ds-misuse judgement
@@ -276,13 +281,13 @@ into [#398](https://github.com/storybookjs/mcp/pull/398) (DS misuse metric,
 open, based on `agentic-reference-eval`). #398 already reshapes the same
 census walk: `count()` takes the element node, an opt-in `nodeList` of
 `NodeRecord`s is emitted for the LLM judge, node paths root at a
-nearest-declaration name, and node lists are stored as `ds-nodes` sidecar
+nearest-declaration name, and node lists are stored as `ds-nodes` census file
 baselines under `metricsVersion` 7.
 
 Changes folded into this plan as a result: owner detection co-located with
 `node-path.ts` under an explicit display-name vs identity-key distinction;
 the walk restructure bound by the path builder's call-once/stable-order
-contract; `NodeRecord.instances`; `metricsVersion` as the invalidation
+contract; node records kept unweighted; `metricsVersion` as the invalidation
 mechanism.
 
 Resolved: this branch (`ds-coverage-weighted`) stacks on the misuse branch,
@@ -291,7 +296,8 @@ regenerates baselines and invalidates cached judgements; mass judging is
 best deferred until this lands.
 
 Deferred follow-up (misuse metric, not this task): judgement records store
-only `{path, file, line, tag}` + scores. Storing the node's `weight`/
-`instances` when zipping the model response back to input nodes would make
-future instance-weighted misuse summaries self-contained instead of
-requiring a re-join against the run's node-list sidecar.
+only `{path, file, line, tag}` + scores. Storing the node's `weight` (and an
+instance figure computed from the owner multiplier) when zipping the model
+response back to input nodes would make future instance-weighted misuse
+summaries self-contained instead of requiring a re-join against the run's
+node census file.


### PR DESCRIPTION
## Summary

Stacked on #402. Instance weighting exposed a structural blind spot in the subsetting-wrapper fold: because wrapper usages collapse straight to the DS identity during the census, no usage edges ever enter the wrapper's own owner bucket — its multiplier floors at 1, and any other local JSX it renders (a slot prop like `footer={<Footer/>}`) inherits that floor. In the mealdrop droppy data, `PageTemplate` is used 9× but `Footer` reported a single instance.

This PR splits the fold into a per-view resolution via a new `wrapped-ds` resolution category:

- **Static aggregates** resolve `wrapped-ds` → `ds`, exactly as before. Every static number stays byte-identical.
- **Weighted aggregates** resolve `wrapped-ds` → `local`: the wrapper's usages feed its own multiplier, slot children inherit it, and DS keeps weighted credit through the wrapper's inner DS JSX × that multiplier — attribution follows the render tree instead of the identity collapse.
- Still a single census pass; nested wrapper chains follow through to the terminal DS identity.

## Effect on real data (droppy-70pc-v2, identical tree)

| metric | before | after |
|---|---|---|
| instances.all | 427 | 683 |
| instances.ds / local | 208.5 / 57.5 | 244.5 / 126.5 |
| iShareAll | 0.488 | 0.358 |
| iShareComp | 0.742 | 0.575 |
| `PageTemplate` (wrapper) multiplier | 1 | 9 |
| `Footer` (slot child) multiplier | 1 | 9 |

Statics are unchanged (shareAll 0.473, shareComp 0.692 on both sides). The old fold flattered the weighted DS share: wrapper usages counted as DS nodes while their slot content barely existed. The honest weighted view sits below static here — DS usage concentrates in written-once wrappers while local slot content is what multiplies.

## Changes

- `types.ts`: `wrapped-ds` resolution carrying both the wrapper's local identity and the DS identity it subsets; which half applies is a per-consumer choice
- `react/resolve.ts`: subsetting wrappers resolve to `wrapped-ds`; nested chains follow through to the terminal DS identity
- `react/census.ts`: usage edges for `wrapped-ds` recorded as for `local`; static totals resolve to `ds`, per-owner instance buckets to `local`
- `identify.ts`: `identityKey`/`memberOf` handle the new category (member access through a wrapper projects onto the DS member)
- Spec doc: degradation invariant amended, `wrapped-ds` architecture documented; the `.map()`/JSX-constant/function-scoped limitations are unaffected and stay
- Baselines + `ds-nodes` sidecars regenerated for the five mealdrop baselines; static fields verified structurally identical against the #402 head. The per-case baselines and the pinned `yannbf__mealdrop@ce507b3` baseline were already at `metricsVersion: 6` on the #402 head and have no local run data to regenerate from — flagging rather than hand-editing.
- Also addresses the open review findings on #402: the `coverageDelta` instance fixture now uses internally consistent totals and asserts `dsShareOfComponentNodes`; the plan doc's function-scoped test snippet is synced with the shipped test. The `CoverageDelta.instances` finding needs no change — the field is required-but-nullable and every consumer optional-chains, so absent and `null` behave identically.

## Verification

- 833/833 tests (three new scenario tests: wrapper with local slot child, chained multipliers through wrappers, member access through a wrapper), typecheck and lint clean
- Static freeze proven twice: scripted structural diff of every committed baseline's static fields against the #402 head, and a live CLI run from both revisions on the identical tree — byte-for-byte equal statics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
